### PR TITLE
Add error output to lambda_handler context

### DIFF
--- a/socless/integrations.py
+++ b/socless/integrations.py
@@ -237,5 +237,7 @@ class StateHandler:
             raise Exception("Result returned from the integration handler is not a Python dictionary. Must be a Python dictionary")
 
         if not self.testing:
+            print("save to s3 result")
+            print(result)
             self.execution_context.save_state_results(self.state_name,result)
         return result

--- a/socless/integrations.py
+++ b/socless/integrations.py
@@ -162,8 +162,7 @@ class ExecutionContext:
         RESULTS_TABLE = os.environ.get('SOCLESS_RESULTS_TABLE')
         results_table = boto3.resource('dynamodb').Table(RESULTS_TABLE)
 
-        if errors:
-            error_expression = ",#results.errors = :e"
+        error_expression = ",#results.errors = :e" if errors else ""
 
         results_table.update_item(
             Key={

--- a/socless/integrations.py
+++ b/socless/integrations.py
@@ -177,7 +177,7 @@ class ExecutionContext:
             ExpressionAttributeNames={
                 "#results": "results",
                 "#name": state_name,
-                "#last_results": '_Last_Saved_Results',
+                "#last_results": '_Last_Saved_Results'
             }
         )
 
@@ -242,5 +242,7 @@ class StateHandler:
             raise Exception("Result returned from the integration handler is not a Python dictionary. Must be a Python dictionary")
 
         if not self.testing:
+            if 'errors' not in self.context:
+                self.context['errors'] = {}
             self.execution_context.save_state_results(self.state_name,result, errors=self.context['errors'])
         return result

--- a/socless/integrations.py
+++ b/socless/integrations.py
@@ -161,11 +161,15 @@ class ExecutionContext:
         """
         RESULTS_TABLE = os.environ.get('SOCLESS_RESULTS_TABLE')
         results_table = boto3.resource('dynamodb').Table(RESULTS_TABLE)
+
+        if errors:
+            error_expression = ",#results.errors = :e"
+
         results_table.update_item(
             Key={
                 "execution_id": self.execution_id
             },
-            UpdateExpression='SET #results.#results.#name = :r, #results.#results.#last_results = :r, #results.errors = :e',
+            UpdateExpression=f'SET #results.#results.#name = :r, #results.#results.#last_results = :r {error_expression}',
             ExpressionAttributeValues={
                 ':r': result,
                 ':e': errors

--- a/socless/integrations.py
+++ b/socless/integrations.py
@@ -162,17 +162,18 @@ class ExecutionContext:
         RESULTS_TABLE = os.environ.get('SOCLESS_RESULTS_TABLE')
         results_table = boto3.resource('dynamodb').Table(RESULTS_TABLE)
 
-        error_expression = ",#results.errors = :e" if errors else ""
+        error_expression = ""
+        expression_attributes = {':r': result}
+        if errors:
+            error_expression = ",#results.errors = :e"
+            expression_attributes[':e'] = errors
 
         results_table.update_item(
             Key={
                 "execution_id": self.execution_id
             },
             UpdateExpression=f'SET #results.#results.#name = :r, #results.#results.#last_results = :r {error_expression}',
-            ExpressionAttributeValues={
-                ':r': result,
-                ':e': errors
-            },
+            ExpressionAttributeValues=expression_attributes,
             ExpressionAttributeNames={
                 "#results": "results",
                 "#name": state_name,

--- a/socless/integrations.py
+++ b/socless/integrations.py
@@ -165,7 +165,7 @@ class ExecutionContext:
             Key={
                 "execution_id": self.execution_id
             },
-            UpdateExpression='SET #results.#results.#name = :r, #results.#results.#last_results = :r, #results.#errors = :e',
+            UpdateExpression='SET #results.#results.#name = :r, #results.#results.#last_results = :r, #results.errors = :e',
             ExpressionAttributeValues={
                 ':r': result,
                 ':e': errors
@@ -173,7 +173,7 @@ class ExecutionContext:
             ExpressionAttributeNames={
                 "#results": "results",
                 "#name": state_name,
-                "#last_results": '_Last_Saved_Results'
+                "#last_results": '_Last_Saved_Results',
             }
         )
 

--- a/socless/integrations.py
+++ b/socless/integrations.py
@@ -150,7 +150,7 @@ class ExecutionContext:
         },ConsistentRead=True)
         item = item_resp.get("Item",{})
         if not item:
-            raise Exception("Error: Unable to get execution_id {} from {}".format(self.execution_id,RESULTS_TABLE))
+            raise Exception("Error: Unable to get execution_id {} from {}".format(self.execution_id, RESULTS_TABLE))
         return item
 
     def save_state_results(self,state_name,result):
@@ -214,7 +214,8 @@ class StateHandler:
                 self.execution_context = ExecutionContext(self.execution_id)
                 self.context = self.execution_context.fetch_context()['results']
                 self.context['execution_id'] = self.execution_id
-                self.context['errors'] = event['errors']
+                if event['errors']:
+                    self.context['errors'] = event['errors']
             else:
                 raise Exception("Execution id not found in non-testing context")
 

--- a/socless/integrations.py
+++ b/socless/integrations.py
@@ -214,6 +214,7 @@ class StateHandler:
                 self.execution_context = ExecutionContext(self.execution_id)
                 self.context = self.execution_context.fetch_context()['results']
                 self.context['execution_id'] = self.execution_id
+                self.context['errors'] = event['errors']
             else:
                 raise Exception("Execution id not found in non-testing context")
 

--- a/socless/integrations.py
+++ b/socless/integrations.py
@@ -214,7 +214,7 @@ class StateHandler:
                 self.execution_context = ExecutionContext(self.execution_id)
                 self.context = self.execution_context.fetch_context()['results']
                 self.context['execution_id'] = self.execution_id
-                if event['errors']:
+                if 'errors' in event:
                     self.context['errors'] = event['errors']
             else:
                 raise Exception("Execution id not found in non-testing context")

--- a/socless/integrations.py
+++ b/socless/integrations.py
@@ -242,7 +242,6 @@ class StateHandler:
             raise Exception("Result returned from the integration handler is not a Python dictionary. Must be a Python dictionary")
 
         if not self.testing:
-            if 'errors' not in self.context:
-                self.context['errors'] = {}
-            self.execution_context.save_state_results(self.state_name,result, errors=self.context['errors'])
+            self.execution_context.save_state_results(self.state_name, result, errors=self.context.get('errors', {}))
+
         return result

--- a/socless/integrations.py
+++ b/socless/integrations.py
@@ -153,7 +153,7 @@ class ExecutionContext:
             raise Exception("Error: Unable to get execution_id {} from {}".format(self.execution_id, RESULTS_TABLE))
         return item
 
-    def save_state_results(self,state_name,result):
+    def save_state_results(self,state_name,result, errors={}):
         """Save the results of a State's execution to the Execution results table
         Args:
             state_name (str): The name of the state
@@ -168,7 +168,7 @@ class ExecutionContext:
             UpdateExpression='SET #results.#results.#name = :r, #results.#results.#last_results = :r, #results.#errors = :e',
             ExpressionAttributeValues={
                 ':r': result,
-                ':e': self.context['errors']
+                ':e': errors
             },
             ExpressionAttributeNames={
                 "#results": "results",
@@ -238,5 +238,5 @@ class StateHandler:
             raise Exception("Result returned from the integration handler is not a Python dictionary. Must be a Python dictionary")
 
         if not self.testing:
-            self.execution_context.save_state_results(self.state_name,result)
+            self.execution_context.save_state_results(self.state_name,result, errors=self.context['errors'])
         return result

--- a/socless/integrations.py
+++ b/socless/integrations.py
@@ -164,10 +164,11 @@ class ExecutionContext:
         results_table.update_item(
             Key={
                 "execution_id": self.execution_id
-                },
-            UpdateExpression='SET #results.#results.#name = :r, #results.#results.#last_results = :r',
+            },
+            UpdateExpression='SET #results.#results.#name = :r, #results.#results.#last_results = :r, #results.#errors = :e',
             ExpressionAttributeValues={
-                ':r': result
+                ':r': result,
+                ':e': self.context['errors']
             },
             ExpressionAttributeNames={
                 "#results": "results",
@@ -237,7 +238,5 @@ class StateHandler:
             raise Exception("Result returned from the integration handler is not a Python dictionary. Must be a Python dictionary")
 
         if not self.testing:
-            print("save to s3 result")
-            print(result)
             self.execution_context.save_state_results(self.state_name,result)
         return result


### PR DESCRIPTION
This pull request adds error output caught by SOCless to the context object sent to handle_state, allowing you to build integrations that will use this error logging to create more fully-featured bug tickets/ exception reporting

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
