### PR TITLE
Add boto3 test requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,6 @@ setup(
 
     keywords='socless security orchestration automation',
     packages=['socless'],
-    install_requires=['simplejson', 'jinja2'],
+    install_requires=['simplejson', 'jinja2', 'boto3'],
     tests_require=['tox']
 )


### PR DESCRIPTION
Socless uses boto3, but setup.py doesn't list it as a requirement.

This patch fixes that issue.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
