### PR TITLE
add playbook to event dict during tests to endpoints

### DIFF
--- a/socless/events.py
+++ b/socless/events.py
@@ -135,6 +135,8 @@ class EventCreator():
             'status_': self.status_,
             'is_duplicate': self.is_duplicate
         }
+        if self.playbook:
+            event['playbook'] = self.playbook 
         event_table.put_item(Item=event)
         return event
 
@@ -189,6 +191,8 @@ class EventBatch():
             event_info['event_type'] = self.event_type
             event_info['event_meta'] = self.event_meta
             event_info['dedup_keys'] = self.dedup_keys
+            if self.playbook:
+                event_info['playbook'] = self.playbook    
 
             event = EventCreator(event_info).create()
             # Trigger execution of a playbook if playbook was supplied


### PR DESCRIPTION
"Playbook" field was missing when triggering playbooks for test runs

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
