### PR TITLE
events.py testing uplift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ venv*
 .cache
 .DS_Store
 .tox
+.coverage

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ venv*
 .DS_Store
 .tox
 .coverage
+htmlcov

--- a/socless/events.py
+++ b/socless/events.py
@@ -105,7 +105,6 @@ class EventCreator():
         if dedup_mapping:
             current_investigation_id = dedup_mapping.get('current_investigation_id')
             if not current_investigation_id:
-                return 2
                 socless_log.warn('unmapped dedup_hash detected in dedup table', {'dedup_hash': self._cached_dedup_hash})
                 return
             current_investigation = event_table.get_item(Key={ 'id': current_investigation_id}).get('Item')

--- a/socless/events.py
+++ b/socless/events.py
@@ -105,13 +105,15 @@ class EventCreator():
         if dedup_mapping:
             current_investigation_id = dedup_mapping.get('current_investigation_id')
             if not current_investigation_id:
+                return 2
                 socless_log.warn('unmapped dedup_hash detected in dedup table', {'dedup_hash': self._cached_dedup_hash})
                 return
-            current_investigation = event_table.get_item(Key={'id': current_investigation_id}).get('Item')
+            current_investigation = event_table.get_item(Key={ 'id': current_investigation_id}).get('Item')
             if current_investigation and current_investigation['status_'] != 'closed':
                 self.investigation_id = current_investigation['investigation_id']
                 self.status_ = 'closed'
                 self.is_duplicate = True
+            
 
         return
 

--- a/socless/events.py
+++ b/socless/events.py
@@ -30,9 +30,7 @@ class EventCreator():
     """Handles the creation of an Event
     """
 
-    def __init__(self,event_info):
-        """
-        """
+    def __init__(self, event_info):
         self.event_info = event_info
 
         self.event_type = event_info.get('event_type')
@@ -78,7 +76,16 @@ class EventCreator():
 
     @property
     def dedup_hash(self):
-        """Property that returns the deduplication hash
+        """Property that returns the deduplication hash.
+
+        Using the keys in the 'dedup_keys' list, build a single string that 
+        includes each associated value in the 'details' field for this event.
+
+        This string will be the same for every event that is triggered
+        with the exact event details and dedup_keys.
+
+        Returns:
+            A hashed string for deduplicating an event triggered twice.
         """
         sorted_dedup_vals = sorted([self.details[key].lower() for key in self.dedup_keys])
         dedup_signature = self.event_type.lower() + ''.join(sorted_dedup_vals)

--- a/socless/events.py
+++ b/socless/events.py
@@ -158,7 +158,7 @@ class EventBatch():
 
         self.created_at = event_batch.get('created_at')
 
-        self.details = event_batch.get('details',[{}])
+        self.details = event_batch.get('details', [{}])
         for each in self.details:
             if not isinstance(each,dict):
                 raise Exception("Error: Details must be a list of dictionaries")
@@ -192,13 +192,14 @@ class EventBatch():
             event_info['event_meta'] = self.event_meta
             event_info['dedup_keys'] = self.dedup_keys
             if self.playbook:
-                event_info['playbook'] = self.playbook    
+                event_info['playbook'] = self.playbook
 
             event = EventCreator(event_info).create()
             # Trigger execution of a playbook if playbook was supplied
             if self.playbook:
                 execution_statuses.append(self.execute_playbook(event,event['investigation_id']))
-        return {"status":True, "message":execution_statuses}
+        
+        return { "status":True, "message":execution_statuses }
 
     def execute_playbook(self,entry,investigation_id=''):
         """Execute a playbook for an event

--- a/socless/events.py
+++ b/socless/events.py
@@ -211,12 +211,14 @@ class EventBatch():
             if self.playbook:
                 execution_statuses.append(self.execute_playbook(event,event['investigation_id']))
         
-        return { "status":True, "message":execution_statuses }
+        #! FIX: Will always return true, message is a list of individual
+        #! playbook responses that may be true or false (error) responses
+        return { "status":True, "message": execution_statuses }
 
     def execute_playbook(self,entry,investigation_id=''):
-        """Execute a playbook for an event
+        """Execute a playbook for a SOCless event.
         Args:
-            event (dict): The event details
+            entry (dict): The event details
             investigation_id (str): The investigation_id to use
             playbook (str): The name of the playbook to execute
         Returns:

--- a/socless/events.py
+++ b/socless/events.py
@@ -112,19 +112,23 @@ class EventCreator():
                 self.investigation_id = current_investigation['investigation_id']
                 self.status_ = 'closed'
                 self.is_duplicate = True
-            
 
         return
 
     def create(self):
-        """Create an event
+        """Create an event.
+
+        Check if event is duplicate, if not then add it to the dedup table.
         """
         # Deduplicate the event if there are dedup keys set
         if self.dedup_keys:
             self.deduplicate()
             # Create/Update dedup_hash mapping if the event is an original
             if not self.is_duplicate:
-                new_dedup_mapping = {'dedup_hash': self._cached_dedup_hash, 'current_investigation_id': self.investigation_id}
+                new_dedup_mapping = {
+                    'dedup_hash': self._cached_dedup_hash,
+                    'current_investigation_id': self.investigation_id
+                }
                 dedup_table.put_item(Item=new_dedup_mapping)
             else:
                 pass

--- a/socless/events.py
+++ b/socless/events.py
@@ -130,8 +130,6 @@ class EventCreator():
                     'current_investigation_id': self.investigation_id
                 }
                 dedup_table.put_item(Item=new_dedup_mapping)
-            else:
-                pass
         else:
             pass
 

--- a/socless/integrations.py
+++ b/socless/integrations.py
@@ -37,7 +37,7 @@ class ParameterResolver:
         Does not support the full JsonPath specification
 
         Args:
-            reference: The JsonPath reference e.g. $.artifacts.investigation_id
+            path: The JsonPath reference e.g. $.artifacts.investigation_id
         Returns:
             The referenced element. May be any Python built-in type
         """

--- a/socless/integrations.py
+++ b/socless/integrations.py
@@ -149,9 +149,10 @@ class ExecutionContext:
         item_resp = results_table.get_item(Key={
             'execution_id': self.execution_id
         },ConsistentRead=True)
-        item = item_resp.get("Item",{})
-        if not item:
-            raise Exception("Error: Unable to get execution_id {} from {}".format(self.execution_id, RESULTS_TABLE))
+        try:
+            item = item_resp['Item']
+        except KeyError as e:
+            raise Exception(f"Error: Unable to get execution_id {self.execution_id} from {RESULTS_TABLE}.")
         return item
 
     def save_state_results(self,state_name,result, errors={}):

--- a/socless/utils.py
+++ b/socless/utils.py
@@ -41,13 +41,14 @@ def gen_datetimenow():
 
 def convert_empty_strings_to_none(nested_dict):
     converted_dict = {}
-    for k, v in nested_dict.items():
-        if isinstance(v, dict):
-            converted_dict[k] = convert_empty_strings_to_none(v)
-        elif isinstance(v, list):
-            converted_dict[k] = [convert_empty_strings_to_none(l_v) for l_v in v]
-        elif isinstance(v, str):
-            converted_dict[k] = v if v else None
-        else:
-            converted_dict[k] = v
+    if isinstance(nested_dict, dict):
+        for k, v in nested_dict.items():
+            if isinstance(v, dict):
+                converted_dict[k] = convert_empty_strings_to_none(v)
+            elif isinstance(v, list):
+                converted_dict[k] = [convert_empty_strings_to_none(l_v) for l_v in v]
+            elif isinstance(v, str):
+                converted_dict[k] = v if v else None
+            else:
+                converted_dict[k] = v
     return converted_dict

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,7 @@ def setup_tables():
         dynamodb_client.create_table(
             TableName=table_name,
             KeySchema=[{'AttributeName': pkey, 'KeyType': 'HASH'}],
-            AttributeDefinitions=[]
+             AttributeDefinitions=[{"AttributeName" : pkey, "AttributeType" : 'S'}]
         )
 
     return dynamodb_client

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -14,12 +14,15 @@
 """
 Helpers
 """
+import os
+
+account_id = os.environ['MOTO_ACCOUNT_ID']
 
 class MockLambdaContext:
     """Mock Lambda context object
     """
 
-    invoked_function_arn = "arn:aws:lambda:us-west-2:200000000:function:_socless_playground"
+    invoked_function_arn = f"arn:aws:lambda:us-west-2:{account_id}:function:_socless_playground"
 
 
 def mock_integration_handler(firstname='', middlename='', lastname=''):

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -13,11 +13,11 @@
 # limitations under the License
 from tests.conftest import * #imports testing boilerplate
 from .helpers import MockLambdaContext
+from pprint import pprint
+from copy import deepcopy
+import pytest
 
-
-def test_create_events():
-    from socless.events import create_events
-    event = {
+MOCK_EVENT_BATCH = {
         "event_type": "ParamsToStateMachineTester",
         "details": [
             {"username": "ubalogun","type": "user","id":"1"},
@@ -28,4 +28,61 @@ def test_create_events():
         "dedup_keys": ["username", "id"]
     }
 
-    assert create_events(event,MockLambdaContext())['status'] == True
+def test_EventBatch():
+    from socless.events import EventBatch
+
+    batched_event = EventBatch(MOCK_EVENT_BATCH, MockLambdaContext())
+
+    assert batched_event.event_type == MOCK_EVENT_BATCH['event_type']
+    assert batched_event.created_at == None # created_at not supplied in mock
+    assert batched_event.details == MOCK_EVENT_BATCH['details']
+    assert batched_event.data_types == {} # created_at not supplied in mock
+    assert batched_event.dedup_keys == MOCK_EVENT_BATCH['dedup_keys']
+    assert batched_event.event_meta == {}
+    assert batched_event.playbook == MOCK_EVENT_BATCH['playbook']
+
+def test_EventBatch_missing_details():
+    from socless.events import EventBatch
+
+    bad_mock_event_batch = deepcopy(MOCK_EVENT_BATCH)
+    del bad_mock_event_batch['details']
+    del bad_mock_event_batch['playbook']
+
+    batched_event = EventBatch(bad_mock_event_batch, MockLambdaContext())
+
+    assert batched_event.playbook == ""
+    assert batched_event.details == [{}]
+
+def test_EventBatch_incorrect_details_type():
+    from socless.events import EventBatch
+
+    bad_mock_event_batch = deepcopy(MOCK_EVENT_BATCH)
+    bad_mock_event_batch['details'] = 'bad_arg'
+
+    with pytest.raises(Exception):
+        batched_event = EventBatch(bad_mock_event_batch, MockLambdaContext())
+
+def test_EventBatch_incorrect_playbook_type():
+    from socless.events import EventBatch
+
+    bad_mock_event_batch = deepcopy(MOCK_EVENT_BATCH)
+    bad_mock_event_batch['playbook'] = ['bad_arg']
+
+    with pytest.raises(Exception):
+        batched_event = EventBatch(bad_mock_event_batch, MockLambdaContext())
+
+def test_EventBatch_incorrect_dedup_keys_type():
+    from socless.events import EventBatch
+
+    bad_mock_event_batch = deepcopy(MOCK_EVENT_BATCH)
+    bad_mock_event_batch['dedup_keys'] = 'bad_arg_type'
+
+    with pytest.raises(Exception):
+        batched_event = EventBatch(bad_mock_event_batch, MockLambdaContext())
+
+def test_create_events():
+    from socless.events import create_events
+
+    create_events_result = create_events(MOCK_EVENT_BATCH, MockLambdaContext())
+
+    assert create_events_result['status'] == True

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -67,7 +67,7 @@ DEDUP_HASH_FOR_MOCK_EVENT = "0caa90ad7b7fc101b90a8ce0f9638eb9"
 MOCK_INVESTIGATION_ID = "mock_investigation_id"
 
 
-def test_EventCreator():
+def test_EventCreator_init_happy():
     event_details = EventCreator(MOCK_EVENT)
 
     assert event_details.event_type == MOCK_EVENT['event_type']
@@ -77,65 +77,75 @@ def test_EventCreator():
     assert event_details.event_meta == {}
     assert event_details.playbook == MOCK_EVENT['playbook']
 
-def test_EventCreator_invalid_date():
+def test_EventCreator_init_fails_on_invalid_date_format():
     edited_event_data = deepcopy(MOCK_EVENT)
     edited_event_data['created_at'] = 'bad_date'
 
     with pytest.raises(Exception):
         event_details = EventCreator(edited_event_data)
 
-def test_EventCreator_invalid_event_type():
+def test_EventCreator_init_fails_on_invalid_event_type():
     edited_event_data = deepcopy(MOCK_EVENT)
     edited_event_data['event_type'] = ''
 
     with pytest.raises(Exception):
         event_details = EventCreator(edited_event_data)
 
-def test_EventCreator_invalid_details():
+def test_EventCreator_init_fails_on_invalid_details():
     edited_event_data = deepcopy(MOCK_EVENT)
     edited_event_data['details'] = ''
 
     with pytest.raises(Exception):
         event_details = EventCreator(edited_event_data)
 
-def test_EventCreator_invalid_data_types():
+def test_EventCreator_init_fails_when_invalid_data_types():
     edited_event_data = deepcopy(MOCK_EVENT)
     edited_event_data['data_types'] = ''
 
     with pytest.raises(Exception):
         event_details = EventCreator(edited_event_data)
 
-def test_EventCreator_invalid_event_meta():
+def test_EventCreator_init_fails_when_details_is_not_dict():
+    edited_event_data = deepcopy(MOCK_EVENT)
+    edited_event_data['details'] = []
+
+    with pytest.raises(Exception):
+        event_details = EventCreator(edited_event_data)
+
+#! this should fail, need to make changes to events.py so this fails
+# def test_EventCreator_fails_when_details_is_empty_dict():
+#     edited_event_data = deepcopy(MOCK_EVENT)
+#     edited_event_data['details'] = {}
+
+#     with pytest.raises(Exception):
+#         event_details = EventCreator(edited_event_data)
+
+def test_EventCreator_init_fails_on_invalid_event_meta():
     edited_event_data = deepcopy(MOCK_EVENT)
     edited_event_data['event_meta'] = ''
 
     with pytest.raises(Exception):
         event_details = EventCreator(edited_event_data)
 
-def test_EventCreator_invalid_playbook():
+def test_EventCreator_init_fails_on_invalid_playbook():
     edited_event_data = deepcopy(MOCK_EVENT)
     edited_event_data['playbook'] = 1234
 
     with pytest.raises(Exception):
         event_details = EventCreator(edited_event_data)
 
-def test_EventCreator_invalid_dedup_keys():
+def test_EventCreator_init_fails_when_dedup_keys_not_a_list():
     edited_event_data = deepcopy(MOCK_EVENT)
     edited_event_data['dedup_keys'] = "key_to_dedupe"
 
     with pytest.raises(Exception):
         event_details = EventCreator(edited_event_data)
 
-def test_EventCreator_dedup_hash():
+def test_EventCreator_dedup_hash_is_correct():
     event = EventCreator(MOCK_EVENT)
     assert event.dedup_hash == DEDUP_HASH_FOR_MOCK_EVENT
 
-    edited_mock_event = deepcopy(MOCK_EVENT)
-    edited_mock_event['dedup_keys'] = ['username']
-    event = EventCreator(edited_mock_event)
-    assert event.dedup_hash == "0caa90ad7b7fc101b90a8ce0f9638eb9"
-
-def test_EventCreator_dedup_hash_invalid_key():
+def test_EventCreator_dedup_hash_fails_when_dedup_keys_do_not_match_any_details():
     edited_mock_event = deepcopy(MOCK_EVENT)
     edited_mock_event['dedup_keys'] = ['invalid_key']
 
@@ -301,7 +311,7 @@ def test_EventBatch_invalid_playbook_type():
     with pytest.raises(Exception):
         batched_event = EventBatch(bad_mock_event_batch, MockLambdaContext())
 
-def test_EventBatch_invalid_dedup_keys_type():
+def test_EventBatch_fails_on_invalid_type_for_dedup_keys():
     bad_mock_event_batch = deepcopy(MOCK_EVENT_BATCH)
     bad_mock_event_batch['dedup_keys'] = 'bad_arg_type'
 

--- a/tests/test_humaninteractions.py
+++ b/tests/test_humaninteractions.py
@@ -63,39 +63,39 @@ TEST_SFN_CONTEXT = {
 }
 
 MOCK_MESSAGE_RESPONSE_ENTRY = dict_to_item({
-  "await_token": TEST_SFN_CONTEXT['task_token'],
-  "execution_id": TEST_SFN_CONTEXT['sfn_context']['execution_id'],
-  "fulfilled": False,
-  "investigation_id": TEST_SFN_CONTEXT['sfn_context']['artifacts']['event']['investigation_id'],
-  "message": TEST_MESSAGE,
-  "receiver": TEST_SFN_CONTEXT['sfn_context']['State_Config']['Name'],
+    "await_token": TEST_SFN_CONTEXT['task_token'],
+    "execution_id": TEST_SFN_CONTEXT['sfn_context']['execution_id'],
+    "fulfilled": False,
+    "investigation_id": TEST_SFN_CONTEXT['sfn_context']['artifacts']['event']['investigation_id'],
+    "message": TEST_MESSAGE,
+    "receiver": TEST_SFN_CONTEXT['sfn_context']['State_Config']['Name'],
 },convert_root=False)
 
 
 MOCK_DB_CONTEXT = {
-  "datetime": "some_point_in_time_and_space",
-  "execution_id": "mock_execution_id",
-  "investigation_id": "mock_investigation_id",
-  "results": {
-    'artifacts': {
-        'event': {
-            'id': MOCK_EVENT_ID,
-            'created_at': 'some_point_in_time_and_space',
-            'data_types': {},
-            'details': {
-                "some": "randon text"
+    "datetime": "some_point_in_time_and_space",
+    "execution_id": "mock_execution_id",
+    "investigation_id": "mock_investigation_id",
+    "results": {
+        'artifacts': {
+            'event': {
+                'id': MOCK_EVENT_ID,
+                'created_at': 'some_point_in_time_and_space',
+                'data_types': {},
+                'details': {
+                    "some": "randon text"
+                },
+                'event_type': 'Test Human Interaction Workflow',
+                'event_meta': {},
+                'investigation_id': MOCK_INVESTIGATION_ID,
+                'status_': 'open',
+                'is_duplicate': False
             },
-            'event_type': 'Test Human Interaction Workflow',
-            'event_meta': {},
-            'investigation_id': MOCK_INVESTIGATION_ID,
-            'status_': 'open',
-            'is_duplicate': False
+            'execution_id': MOCK_EXECUTION_ID
         },
-        'execution_id': MOCK_EXECUTION_ID
-    },
-    "errors": {},
-    "results": {}
-  }
+        "errors": {},
+        "results": {}
+    }
 }
 
 @pytest.fixture

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -131,7 +131,8 @@ def root_obj():
                 "details": {
                     "firstname": "Sterling",
                     "middlename": "Malory",
-                    "lastname": "Archer"
+                    "lastname": "Archer",
+                    "vault_test" : "vault:socless_vault_tests.txt"
                 }
             }
         }
@@ -150,8 +151,11 @@ def TestExecutionContext():
 def test_resolve_jsonpath(TestParamResolver, root_obj):
     assert TestParamResolver.resolve_jsonpath("$.artifacts.event.details.firstname") == root_obj['artifacts']['event']['details']['firstname']
 
-def test_resolve_vault_path(TestParamResolver):
+def test_resolve_jsonpath_vault_token(TestParamResolver, root_obj):
+    assert TestParamResolver.resolve_jsonpath("$.artifacts.event.details.vault_test") == "this came from the vault"
 
+
+def test_resolve_vault_path(TestParamResolver):
     assert TestParamResolver.resolve_vault_path("vault:socless_vault_tests.txt") == "this came from the vault"
 
 def test_resolve_reference(TestParamResolver):
@@ -163,6 +167,8 @@ def test_resolve_reference(TestParamResolver):
     assert TestParamResolver.resolve_reference("vault:socless_vault_tests.txt") == "this came from the vault"
     # Test with dictionary reference
     assert TestParamResolver.resolve_reference({"firstname": "$.artifacts.event.details.firstname"}) == {"firstname": "Sterling"}
+    # Test with not dict or string reference
+    assert TestParamResolver.resolve_reference(['test']) == ["test"]
 
 def test_resolve_parameters(TestParamResolver):
     # Test with static string, vault reference, JsonPath reference, and conversion

--- a/tox.ini
+++ b/tox.ini
@@ -26,8 +26,12 @@ deps =
    boto3
    moto==1.3.13
    simplejson
+   pytest-cov
 commands =
-   pytest tests -vv {posargs}
+   ; pytest tests -vv {posargs}
+   ; coverage run -m pytest tests -vv
+   ; coverage report -m
+   pytest --cov=socless tests -vv
 
 [pytest]
 testpaths = tests

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,6 @@ deps =
    simplejson
    pytest-cov
 commands =
-   pytest --cov=socless tests -vv
-
+   pytest --cov-report term-missing --cov=socless tests -vv
 [pytest]
 testpaths = tests

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ setenv =
    SOCLESS_MESSAGE_RESPONSE_TABLE=mock_message_responses
    SOCLESS_VAULT=socless-dev-soclessvault-xxxxxxxx
    SOCLESS_DEDUP_TABLE=socless_dedup
+   MOTO_ACCOUNT_ID=123456789012
    AWS_REGION=us-west-2
    AWS_DEFAULT_REGION=us-west-2
    AWS_ACCESS_KEY_ID=testing
@@ -24,7 +25,7 @@ deps =
    pytest
    jinja2
    boto3
-   moto==1.3.13
+   moto==1.3.14
    simplejson
    pytest-cov
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -28,9 +28,6 @@ deps =
    simplejson
    pytest-cov
 commands =
-   ; pytest tests -vv {posargs}
-   ; coverage run -m pytest tests -vv
-   ; coverage report -m
    pytest --cov=socless tests -vv
 
 [pytest]


### PR DESCRIPTION

- Bumped moto to 1.3.14 and added tox env variable for moto_account_id to allow testing of the step functions api

- Added coverage reporting for unit tests.

- Improved descriptions for `events.py` function docstrings.

- Increased testing coverage on `events.py` to 100%

- Revisited all `events.py` test cases to ensure completeness. 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
