### PR TITLE
100% test coverage for logger, s3, vault.py

### DIFF
--- a/socless/vault.py
+++ b/socless/vault.py
@@ -22,7 +22,7 @@ VAULT_TOKEN = "vault:"
 SOCLESS_VAULT = os.environ['SOCLESS_VAULT']
 
 def save_to_vault(content, prefix=""):
-    """Save content to the Vault
+    """Save content to the Vault.
 
     Args:
         content (str): The string to save to the Socless vault
@@ -38,13 +38,14 @@ def save_to_vault(content, prefix=""):
         file_id = prefix + file_id
     bucket.put_object(Key=file_id,Body=content) #TODO: Should I try catch or let it fail here
     result = {
-    "file_id": file_id,
-    "vault_id": "{}{}".format(VAULT_TOKEN,file_id)
+        "file_id": file_id,
+        "vault_id": "{}{}".format(VAULT_TOKEN,file_id)
     }
+
     return result
 
 def fetch_from_vault(file_id,content_only=False):
-    """Fetch an item from the Vault
+    """Fetch an item from the Vault.
 
     Args:
         file_id (string): Path to object in the Vault
@@ -64,20 +65,21 @@ def fetch_from_vault(file_id,content_only=False):
     }
     if content_only:
         return meta["content"]
+    
     return meta
 
 def remove_from_vault(file_id):
-    """Remove an item from the Vault
+    """Remove an item from the Vault.
 
     Args:
         file_id (string): Path to object in the Vault
 
     Returns:
         dict: The response metadata of the attempt to remove the obejct from vault
-
     """
     s3 = boto3.resource('s3')
     bucket = s3.Bucket(SOCLESS_VAULT)
     obj = bucket.Object(file_id)
     data = obj.delete()
+
     return data

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -13,7 +13,6 @@
 # limitations under the License
 from tests.conftest import * #imports testing boilerplate
 from .helpers import MockLambdaContext, dict_to_item
-from pprint import pprint
 import json, os
 from copy import deepcopy
 import pytest
@@ -341,7 +340,6 @@ def test_EventBatch_execute_playbook():
     batched_event = EventBatch(MOCK_EVENT_BATCH, MockLambdaContext())
     result = batched_event.execute_playbook(convert_empty_strings_to_none(MOCK_EVENT))
 
-    pprint(result)
     assert result['status'] == True
     assert isinstance(result['message']['execution_id'], str)
     assert isinstance(result['message']['investigation_id'], str)

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,86 @@
+# Copyright 2018 Twilio, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+from tests.conftest import * #imports testing boilerplate
+from .helpers import MockLambdaContext, dict_to_item
+import json, os
+from copy import deepcopy
+import pytest
+from moto import mock_stepfunctions, mock_sts, mock_iam
+
+from socless.logger import socless_log, socless_log_then_raise
+
+
+bucket_name = os.environ['SOCLESS_VAULT']
+
+def test_socless_log_then_raise():
+    with pytest.raises(Exception):
+        socless_log_then_raise('testing error')
+
+def test_socless_log_fails_on_empty_message():
+    with pytest.raises(ValueError):
+        socless_log_then_raise('')
+
+def test_socless_log_fails_on_extra_not_being_dict():
+    with pytest.raises(ValueError):
+        socless_log_then_raise('test_message', [])
+
+def test_socless_log_error(capfd):
+    level = "ERROR"
+    response = socless_log.error("Testing")
+    
+    # Read logging and convert to dict for assertion
+    out, err = capfd.readouterr()
+    json_out = json.loads(out)
+    assert json_out['context']['level'] == level
+    assert json_out['body']['message'] == "Testing"
+
+def test_socless_log_info(capfd):
+    level = "INFO"
+    response = socless_log.info("Testing")
+    
+    # Read logging and convert to dict for assertion
+    out, err = capfd.readouterr()
+    json_out = json.loads(out)
+    assert json_out['context']['level'] == level
+    assert json_out['body']['message'] == "Testing"
+
+def test_socless_log_warn(capfd):
+    level = "WARN"
+    response = socless_log.warn("Testing")
+    
+    # Read logging and convert to dict for assertion
+    out, err = capfd.readouterr()
+    json_out = json.loads(out)
+    assert json_out['context']['level'] == level
+    assert json_out['body']['message'] == "Testing"
+
+def test_socless_log_critical(capfd):
+    level = "CRITICAL"
+    response = socless_log.critical("Testing")
+    
+    # Read logging and convert to dict for assertion
+    out, err = capfd.readouterr()
+    json_out = json.loads(out)
+    assert json_out['context']['level'] == level
+    assert json_out['body']['message'] == "Testing"
+
+def test_socless_log_debug(capfd):
+    level = "DEBUG"
+    response = socless_log.debug("Testing")
+    
+    # Read logging and convert to dict for assertion
+    out, err = capfd.readouterr()
+    json_out = json.loads(out)
+    assert json_out['context']['level'] == level
+    assert json_out['body']['message'] == "Testing"

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -27,11 +27,11 @@ def test_socless_log_then_raise():
     with pytest.raises(Exception):
         socless_log_then_raise('testing error')
 
-def test_socless_log_fails_on_empty_message():
+def test_socless_log_then_raise_fails_on_empty_message():
     with pytest.raises(ValueError):
         socless_log_then_raise('')
 
-def test_socless_log_fails_on_extra_not_being_dict():
+def test_socless_log_then_raise_fails_on_extra_not_being_dict():
     with pytest.raises(ValueError):
         socless_log_then_raise('test_message', [])
 

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1,0 +1,75 @@
+# Copyright 2018 Twilio, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+from tests.conftest import * #imports testing boilerplate
+from .helpers import MockLambdaContext, dict_to_item
+import json, os
+from copy import deepcopy
+import pytest
+from moto import mock_stepfunctions, mock_sts, mock_iam
+
+from socless.s3 import save_to_s3
+
+
+bucket_name = os.environ['SOCLESS_VAULT']
+
+def test_save_to_s3():
+    file_id = 'test_file_one.json'
+    content = {"Heres a file" : "Heres the value"}
+    
+    response = save_to_s3(file_id, content, bucket_name, True)
+
+    #check bucket for item
+    s3 = boto3.resource('s3')
+    bucket = s3.Bucket(bucket_name)
+    obj = bucket.Object(file_id)
+    data = obj.get()['Body'].read().decode('utf-8')
+
+    assert json.loads(data) == content
+    assert response['file_id'] == file_id
+    assert response['full_path'] == f"{bucket_name}/{response['file_id']}"
+    assert content == response['content']
+
+def test_save_to_s3_fails_on_invalid_content():
+    file_id = 'test_file_one.json'
+    class Class_No_JSONSerialization:
+        pass
+
+    content = Class_No_JSONSerialization()
+
+    with pytest.raises(TypeError):
+        save_to_s3(file_id, content, bucket_name, True)
+
+def test_save_to_s3_no_return_content():
+    file_id = 'test_file_one.json'
+    content = {"Heres a file" : "Heres the value"}
+    
+    response = save_to_s3(file_id, content, bucket_name)
+    
+    #check bucket for item
+    s3 = boto3.resource('s3')
+    bucket = s3.Bucket(bucket_name)
+    obj = bucket.Object(file_id)
+    data = obj.get()['Body'].read().decode('utf-8')
+    
+    assert json.loads(data) == content
+    assert response['file_id'] == file_id
+    assert response['full_path'] == f"{bucket_name}/{response['file_id']}"
+
+def test_save_to_s3_fails_on_missing_bucket():
+    file_id = 'test_file_one.json'
+    content = {"Heres a file" : "Heres the value"}
+    
+    with pytest.raises(Exception):
+        response = save_to_s3(file_id, content, 'bad_bucket_name')
+

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -1,0 +1,99 @@
+# Copyright 2018 Twilio, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+from tests.conftest import * #imports testing boilerplate
+from .helpers import MockLambdaContext, dict_to_item
+import json, os
+from copy import deepcopy
+import pytest
+from moto import mock_stepfunctions, mock_sts, mock_iam
+
+from socless.vault import save_to_vault, fetch_from_vault, remove_from_vault
+
+
+bucket_name = os.environ['SOCLESS_VAULT']
+
+def test_save_to_vault():
+    content = "Test_Content"
+    response = save_to_vault(content)
+
+    #check bucket for item
+    s3 = boto3.resource('s3')
+    bucket = s3.Bucket(bucket_name)
+    obj = bucket.Object(response['file_id'])
+    data = obj.get()['Body'].read().decode('utf-8')
+
+    assert response['vault_id'] == f"vault:{response['file_id']}"
+    assert data == content
+    
+
+def test_save_to_vault_with_prefix():
+    content = "Test_Content"
+    prefix = "test_prefix"
+    response = save_to_vault(content, prefix)
+
+    #check bucket for item
+    s3 = boto3.resource('s3')
+    bucket = s3.Bucket(bucket_name)
+    obj = bucket.Object(response['file_id'])
+    data = obj.get()['Body'].read().decode('utf-8')
+
+    assert prefix in response['vault_id']
+    assert response['vault_id'] == f"vault:{response['file_id']}"
+    assert data == content
+
+def test_fetch_from_vault():
+    # setup by adding test item in vault
+    content = "Test_Content"
+    setup = save_to_vault(content)
+    file_id = setup['file_id']
+
+    response = fetch_from_vault(file_id)
+
+    assert response['content'] == content
+
+def test_fetch_from_vault_content_only():
+    # setup by adding test item in vault
+    content = "Test_Content"
+    setup = save_to_vault(content)
+    file_id = setup['file_id']
+
+    response = fetch_from_vault(file_id, True)
+
+    assert response == content
+
+def test_fetch_from_vault_fails_with_wrong_file_id():
+    # setup by adding test item in vault
+    content = "Test_Content"
+    setup = save_to_vault(content)
+    file_id = setup['file_id']
+
+    with pytest.raises(Exception):
+        response = fetch_from_vault('bad_file_id')
+
+def test_remove_from_vault():
+    # setup by adding test item in vault
+    content = "Test_Content"
+    setup = save_to_vault(content)
+    file_id = setup['file_id']
+
+    response = remove_from_vault(file_id)
+
+    assert response['ResponseMetadata']['HTTPStatusCode'] == 204
+
+    # response code is always 204, manually check if item was deleted
+    s3 = boto3.resource('s3')
+    bucket = s3.Bucket(bucket_name)
+    obj = bucket.Object(file_id)
+    with pytest.raises(Exception):
+        data = obj.get()['Body'].read().decode('utf-8')


### PR DESCRIPTION
Added complete unit testing for 3 files, `logger.py`, `s3.py` & `vault.py`

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
