### PR TITLE
Enable parsing of parameters that are nested within a list

### DIFF
--- a/socless/integrations.py
+++ b/socless/integrations.py
@@ -85,6 +85,11 @@ class ParameterResolver:
                 for key, value in list(reference_path.items()):
                     resolved_dict[key] = self.resolve_reference(value)
                 return resolved_dict
+            elif isinstance(reference_path, list):
+                resolved_list = []
+                for item in reference_path:
+                    resolved_list.append(self.resolve_reference(item))
+                return resolved_list
             else:
                 return reference_path
 
@@ -153,7 +158,7 @@ class ExecutionContext:
         item = item_resp.get("Item", {})
         if not item:
             raise Exception(f"Error: Unable to get execution_id {self.execution_id} from {RESULTS_TABLE}.")
-        
+
         return item
 
     def save_state_results(self,state_name,result, errors={}):


### PR DESCRIPTION
This enables parsing of parameters within a list object. Socless will attempt to identify parameters within the list and resolve them all.

For example, if the context object is...
```
{
        "artifacts": {
            "event": {
                "details": {
                    "firstname": "Sterling",
                    "middlename": "Malory",
                    "lastname": "Archer",
                }
            }
        }
    }
```

...The supplied parameter 
```
{
        "acquaintances": [
            {
                "firstname": "$.artifacts.event.details.middlename",
                "lastname": "$.artifacts.event.details.lastname"
            },
           "$.artifacts.event.details.middlename"
        ]
}
```
Will be resolved to  to 

```
{"acquaintances": [{"firstname": "Malory", "lastname": "Archer"}, "Malory"]}
```

Both the dict and string parameters within the list will be resolved.


Tests have been included in this PR to reflect the implemented behavior



**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
