### PR TITLE
enable direct invocation of lambdas outside of playbooks, without boilerplate

### DIFF
--- a/socless/aws_classes.py
+++ b/socless/aws_classes.py
@@ -1,0 +1,41 @@
+# this code is pulled from here: https://gist.github.com/alexcasalboni/a545b68ee164b165a74a20a5fee9d133
+# actual full lambda context can be seen here: https://github.com/aws/aws-lambda-python-runtime-interface-client/blob/main/awslambdaric/lambda_context.py
+""" Note: this code is used only by the static type checker! """
+from typing import Dict, Any
+
+LambdaDict = Dict[str, Any]
+
+
+class LambdaCognitoIdentity(object):
+    cognito_identity_id: str
+    cognito_identity_pool_id: str
+
+
+class LambdaClientContextMobileClient(object):
+    installation_id: str
+    app_title: str
+    app_version_name: str
+    app_version_code: str
+    app_package_name: str
+
+
+class LambdaClientContext(object):
+    client: LambdaClientContextMobileClient
+    custom: LambdaDict
+    env: LambdaDict
+
+
+class LambdaContext(object):
+    function_name: str
+    function_version: str
+    invoked_function_arn: str
+    memory_limit_in_mb: int
+    aws_request_id: str
+    log_group_name: str
+    log_stream_name: str
+    identity: LambdaCognitoIdentity
+    client_context: LambdaClientContext
+
+    @staticmethod
+    def get_remaining_time_in_millis() -> int:
+        return 0

--- a/socless/exceptions.py
+++ b/socless/exceptions.py
@@ -19,3 +19,7 @@ Socless Exception classes
 
 class SoclessException(Exception):
     pass
+
+
+class SoclessBootstrapError(Exception):
+    pass

--- a/socless/integrations.py
+++ b/socless/integrations.py
@@ -228,7 +228,7 @@ class StateHandler:
         except KeyError:
             # not triggered from socless playbook (direct invoke via CLI, Test console, etc.)
             if "execution_id" not in self.event and "artifacts" not in self.event:
-                print(
+                socless_log.info(
                     "No State_Config was passed to the integration, likely due to invocation \
 from outside of a SOCless playbook. Running this lambda in test mode."
                 )

--- a/socless/socless.py
+++ b/socless/socless.py
@@ -19,11 +19,9 @@ import boto3, os, uuid, simplejson as json, inspect
 from botocore.exceptions import ClientError
 from datetime import datetime
 from .jinja import jinja_env
-from .integrations import StateHandler
 
 # TODO: Deprecate socless_credentials
 __all__ = [
-    "socless_bootstrap",
     "socless_log",
     "socless_gen_id",
     "socless_credentials",
@@ -761,27 +759,3 @@ def socless_fetch_execution_result(execution_id, state_name):
             )
         )
     return item
-
-
-def socless_bootstrap(event, context, handler, include_event=False):
-    """Setup and run an integration's business logic
-
-    Args:
-        event (dict): The Lambda event object
-        context (obj): The Lambda context object
-        handler (func): The handler for the integration
-        include_event (bool): Indicates whether to make the full event object available
-            to the handler
-    Returns:
-        Dict containing the result of executing the integration
-    """
-    state_handler = StateHandler(event, context, handler, include_event=include_event)
-    result = state_handler.execute()
-    # README: Below code includes state_name with result so that parameters can be passed to choice state in the same way
-    # they are passed to integrations (i.e. with $.results.State_Name.parameters)
-    # However, maintain current status quo so that Choice states in current playbooks don't break
-    # TODO: Once Choice states in current playbooks have been updated to the new_style, update this code so result's are only nested under state_name
-    result_with_state_name = {state_handler.state_name: result}
-    result_with_state_name.update(result)
-    event["results"] = result_with_state_name
-    return event

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -15,6 +15,7 @@ import boto3, pytest, os
 from tests.conftest import *  #imports testing boilerplate
 from socless.integrations import ParameterResolver, StateHandler, ExecutionContext
 from socless.utils import gen_id
+from socless.exceptions import SoclessBootstrapError
 from .helpers import mock_integration_handler, mock_integration_handler_return_string, MockLambdaContext, mock_sfn_db_context, mock_execution_results_table_entry
 
 
@@ -359,7 +360,7 @@ def test_StateHandler_init_fails_on_live_event_missing_Name():
         }
     }
 
-    with pytest.raises(KeyError, match="`Name` not set in State_Config"):
+    with pytest.raises(SoclessBootstrapError, match="`Name` not set in State_Config"):
         StateHandler(live_event, MockLambdaContext(), mock_integration_handler)
 
 
@@ -377,7 +378,7 @@ def test_StateHandler_init_fails_on_live_event_missing_Parameters():
         }
     }
 
-    with pytest.raises(KeyError, match="`Parameters` not set in State_Config"):
+    with pytest.raises(SoclessBootstrapError, match="`Parameters` not set in State_Config"):
         StateHandler(live_event, MockLambdaContext(), mock_integration_handler)
 
 


### PR DESCRIPTION
- moved socless_bootstrap from `.socless` to `.integrations`
- check if socless execution boilerplate is present. if not, assume that the lambda `event` is just the raw args for `handle_state`
- build testing boilerplate around the raw args provided in event
- updated the test for missing `State_Config` from asserting an error to asserting a test event

## Description of changes:
If `"State_Config"`, `"execution_id"`, `"artifacts"` are all missing from the lambda event, assume the lambda has been triggered from outside of a playbook & without boilerplate. 

For example, `socless-slack`'s `send_message` lambda has the following args for handle state:
```
def handle_state(context, message_template, target, target_type):
```

Normally, you would test this via the lambda console with:
```
event =
{
  "_testing": true,
  "State_Config": {
    "Name": "test",
    "Parameters": {
      "target": "shunt", 
      "target_type": "user",
      "message_template": "Hello there!"
    }
  }
}
```

With this PR, the invoking event would just be the (non-context) args:
```
event = 
{
      "target": "shunt", 
      "target_type": "user",
      "message_template": "Hello there!"
}
```


----
**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
