### PR TITLE
BUGFIX: export socless_bootstrap correctly

### DIFF
--- a/socless/__init__.py
+++ b/socless/__init__.py
@@ -17,3 +17,4 @@ from .vault import *
 from .humaninteraction import init_human_interaction, end_human_interaction
 from .s3 import *
 from .utils import *
+from .integrations import socless_bootstrap

--- a/socless/__init__.py
+++ b/socless/__init__.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License
+
+# flake8: noqa
 from .socless import *
 from .events import create_events
 from .vault import *

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -18,7 +18,6 @@ from socless.utils import gen_id
 from socless.exceptions import SoclessBootstrapError
 from .helpers import mock_integration_handler, mock_integration_handler_return_string, MockLambdaContext, mock_sfn_db_context, mock_execution_results_table_entry
 
-
 @pytest.fixture()
 def root_obj():
     # setup root_obj for use in tesing TestParamResolver
@@ -494,3 +493,7 @@ def test_StateHandler_execute_with_live_event_returning_non_dict():
     state_handler = StateHandler(event, MockLambdaContext(), mock_integration_handler_return_string)
     with pytest.raises(Exception, match="Result returned from the integration handler is not a Python dictionary. Must be a Python dictionary"):
         state_handler.execute()
+
+
+def test_socless_bootstrap_can_be_imported():
+    from socless import socless_bootstrap # noqa: F401, E261


### PR DESCRIPTION
as noticed by socless community member [here](https://socless.slack.com/archives/CK1G0R6HM/p1612289546036600?thread_ts=1612205122.033000&cid=CK1G0R6HM)

updated tests so this doesnt happen again

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
