### PR TITLE
Enable automatic jinja templating for all strings passed from playbooks

### DIFF
--- a/socless/integrations.py
+++ b/socless/integrations.py
@@ -98,18 +98,17 @@ def convert_legacy_reference_to_template(reference_path: str) -> str:
         "<something>!json" |  "{<something> | fromjson}"
     """
     try:
-        template = reference_path
-
-        if template.startswith(PATH_TOKEN):
-            _, _, conversion = template.partition(CONVERSION_TOKEN)
-            template = f"context{template[1:]}"
+        # modify template if it starts with `$.` or `vault:`
+        if reference_path.startswith(PATH_TOKEN):
+            _, _, conversion_check = reference_path.partition(CONVERSION_TOKEN)
+            jinja_dict_referencing = f"context{reference_path[1:]}"
             return add_brackets_and_conditionally_add_fromjson(
-                template, bool(conversion)
+                jinja_dict_referencing, bool(conversion_check)
             )
-        elif template.startswith(VAULT_TOKEN):
-            template = convert_deprecated_vault_to_template(template)
+        elif reference_path.startswith(VAULT_TOKEN):
+            return convert_deprecated_vault_to_template(reference_path)
 
-        return template
+        return reference_path
     except (TypeError, KeyError) as e:
         raise SoclessException(
             f"Unable to convert reference type {type(reference_path)} to template - {e}"

--- a/socless/integrations.py
+++ b/socless/integrations.py
@@ -43,7 +43,7 @@ class ParameterResolver:
         Returns:
             The referenced element. May be any Python built-in type
         """
-        _pre, _sep, post = path.partition(PATH_TOKEN)
+        _, _, post = path.partition(PATH_TOKEN)
         keys = post.split(".")
         obj_copy = self.root_obj.copy()
         for key in keys:
@@ -54,7 +54,8 @@ class ParameterResolver:
                     f"Unable to resolve key {key}, parent object does not exist. Full path: {path}"
                 )
             if isinstance(value, str) and value.startswith(VAULT_TOKEN):
-                actual = self.resolve_vault_path(value)
+                _, _, file_id = value.partition(VAULT_TOKEN)
+                actual = fetch_from_vault(file_id, content_only=True)
             else:
                 actual = value
             obj_copy = actual
@@ -72,7 +73,7 @@ class ParameterResolver:
         Returns:
             str: The content of the referenced Vault object
         """
-        _, __, file_id = path.partition(VAULT_TOKEN)
+        _, _, file_id = path.partition(VAULT_TOKEN)
         data = fetch_from_vault(file_id, content_only=True)
         return data
 
@@ -105,7 +106,8 @@ class ParameterResolver:
             resolved = self.resolve_jsonpath(reference)
         elif reference_path.startswith(VAULT_TOKEN):
             reference, _, conversion = reference_path.partition(CONVERSION_TOKEN)
-            resolved = self.resolve_vault_path(reference)
+            _, _, file_id = reference.partition(VAULT_TOKEN)
+            resolved = fetch_from_vault(file_id, content_only=True)
         else:
             return reference_path
 
@@ -139,6 +141,8 @@ class ParameterResolver:
         """
         if conversion == "json":
             return json.loads(data)
+        else:
+            raise NotImplementedError("Conversion only supports 'json'")
 
 
 class ExecutionContext:

--- a/socless/integrations.py
+++ b/socless/integrations.py
@@ -335,4 +335,9 @@ def socless_template_string(message, context):
         str: The rendered template
     """
     template = jinja_env.from_string(message)
-    return template.render(context=context).replace("&#34;", '"').replace("&#39;", "'")
+
+    return (
+        str(template.render(context=context))
+        .replace("&#34;", '"')
+        .replace("&#39;", "'")
+    )

--- a/socless/integrations.py
+++ b/socless/integrations.py
@@ -21,7 +21,7 @@ from .utils import convert_empty_strings_to_none
 from .exceptions import SoclessException, SoclessBootstrapError
 from .aws_classes import LambdaContext
 from .jinja import render_jinja_from_string
-from jinja2.exceptions import TemplateSyntaxError
+from jinja2.exceptions import TemplateSyntaxError, UndefinedError
 
 VAULT_TOKEN = "vault:"
 PATH_TOKEN = "$."
@@ -127,7 +127,7 @@ def resolve_string_parameter(parameter: str, root_object: dict) -> Any:
 
             ## autoescaping is currently disabled, this line may not be necessary
             # resolved = resolved.replace("&#34;", '"').replace("&#39;", "'")
-    except TemplateSyntaxError as e:
+    except (TemplateSyntaxError, UndefinedError) as e:
         print(f"Invalid jinja template error {e} | for template: {template}")
         return template
     return resolved
@@ -315,7 +315,7 @@ def socless_bootstrap(
 
 
 def socless_template_string(message, context):
-    """Render a templated string
+    """DEPRECATED -- Render a templated string.
 
     Args:
         message (str): The templated string to render
@@ -327,6 +327,6 @@ def socless_template_string(message, context):
     try:
         resolved = render_jinja_from_string(message, context)
         return str(resolved)
-    except TemplateSyntaxError as e:
+    except (TemplateSyntaxError, UndefinedError) as e:
         print(f"socless_template_string failed due to syntax error : {e}")
         return message

--- a/socless/integrations.py
+++ b/socless/integrations.py
@@ -27,6 +27,7 @@ from .jinja import jinja_env
 VAULT_TOKEN = "vault:"
 PATH_TOKEN = "$."
 CONVERSION_TOKEN = "!"
+vault_pattern = re.compile(r"(vault:)(\S+(?=\s|$))(.*)")
 
 
 class ParameterResolver:
@@ -181,8 +182,7 @@ def convert_legacy_reference_to_template(reference_path: str):
             needs_brackets = True
             template = template.replace("$.", "context.")
 
-        pattern = r"(vault:)(\S+(?=\s|$))(.*)"
-        vault_matches = re.search(pattern, template)
+        vault_matches = re.search(vault_pattern, template)
         if vault_matches:
             needs_brackets = True
             template = f"vault('{vault_matches.group(2)}') {vault_matches.group(3)}"

--- a/socless/integrations.py
+++ b/socless/integrations.py
@@ -127,9 +127,15 @@ def resolve_string_parameter(parameter: str, root_object: dict) -> Any:
 
             ## autoescaping is currently disabled, this line may not be necessary
             # resolved = resolved.replace("&#34;", '"').replace("&#39;", "'")
-    except (TemplateSyntaxError, UndefinedError) as e:
-        print(f"Invalid jinja template error {e} | for template: {template}")
+    except TemplateSyntaxError as e:
+        socless_log.warn(
+            f"Invalid jinja Template Syntax error {e} | for template: {template}"
+        )
         return template
+    except UndefinedError as e:
+        raise SoclessBootstrapError(
+            f"Undefined variable when resolving parameter: {parameter} template {e} | for template: {template}"
+        )
     return resolved
 
 

--- a/socless/integrations.py
+++ b/socless/integrations.py
@@ -106,20 +106,6 @@ class ParameterResolver:
         else:
             return reference_path
 
-        if reference_path.startswith(PATH_TOKEN):
-            reference, _, conversion = reference_path.partition(CONVERSION_TOKEN)
-            resolved = self.resolve_jsonpath(reference)
-        elif reference_path.startswith(VAULT_TOKEN):
-            reference, _, conversion = reference_path.partition(CONVERSION_TOKEN)
-            _, _, file_id = reference.partition(VAULT_TOKEN)
-            resolved = fetch_from_vault(file_id, content_only=True)
-        else:
-            return reference_path
-
-        if conversion:
-            resolved = self.apply_conversion_from(resolved, conversion)
-        return resolved
-
     def resolve_parameters(self, parameters):
         """Resolve a set of parameter references to their actual vaules
 

--- a/socless/integrations.py
+++ b/socless/integrations.py
@@ -71,13 +71,19 @@ class ParameterResolver:
         return actual_params
 
 
+def add_brackets_and_conditionally_add_fromjson(
+    template: str, should_add_fromjson: bool
+):
+    if should_add_fromjson:
+        template = template + " |fromjson"
+    return "{" + template + "}"
+
+
 def convert_deprecated_vault_to_template(vault_reference) -> str:
     reference, _, conversion = vault_reference.partition(CONVERSION_TOKEN)
     _, _, file_id = reference.partition(VAULT_TOKEN)
     template = f"vault('{file_id}')"
-    if conversion:
-        template = template + " |fromjson"
-    return "{" + template + "}"
+    return add_brackets_and_conditionally_add_fromjson(template, bool(conversion))
 
 
 def convert_legacy_reference_to_template(reference_path: str) -> str:
@@ -97,9 +103,9 @@ def convert_legacy_reference_to_template(reference_path: str) -> str:
         if template.startswith(PATH_TOKEN):
             _, _, conversion = template.partition(CONVERSION_TOKEN)
             template = f"context{template[1:]}"
-            if conversion:
-                template = template + " |fromjson"
-            template = "{" + template + "}"
+            return add_brackets_and_conditionally_add_fromjson(
+                template, bool(conversion)
+            )
         elif template.startswith(VAULT_TOKEN):
             template = convert_deprecated_vault_to_template(template)
 

--- a/socless/integrations.py
+++ b/socless/integrations.py
@@ -324,5 +324,9 @@ def socless_template_string(message, context):
     Returns:
         str: The rendered template
     """
-    resolved = render_jinja_from_string(message, context)
-    return str(resolved)
+    try:
+        resolved = render_jinja_from_string(message, context)
+        return str(resolved)
+    except TemplateSyntaxError as e:
+        print(f"socless_template_string failed due to syntax error : {e}")
+        return message

--- a/socless/jinja.py
+++ b/socless/jinja.py
@@ -14,6 +14,7 @@
 """
 Code for Jinja2 which Socless uses for templating strings
 """
+from socless.exceptions import SoclessBootstrapError
 from typing import Any
 import json
 from jinja2.nativetypes import NativeEnvironment
@@ -61,7 +62,12 @@ def vault(vault_id: str):
 def fromjson(string_json: str) -> Any:
     # This is a custom jinja Filter which expects stringified json and returns
     # the output of calling json.loads on it.
-    return json.loads(string_json)
+    try:
+        return json.loads(string_json)
+    except json.decoder.JSONDecodeError as e:
+        raise SoclessBootstrapError(
+            f"JSONDecodeError in `fromjson` Jinja filter/function. Error: {e} |\n String: {string_json}"
+        )
 
 
 # Add Custom Functions

--- a/socless/jinja.py
+++ b/socless/jinja.py
@@ -37,8 +37,6 @@ jinja_env = NativeEnvironment(
     # More on undefined types here https://jinja.palletsprojects.com/en/2.11.x/api/#undefined-types
 )
 
-# Define Custom Filters
-
 
 def maptostr(target_list):
     """Casts a list of python types to a list of strings

--- a/socless/jinja.py
+++ b/socless/jinja.py
@@ -55,7 +55,6 @@ def vault(vault_id: str):
     # A custom jinja Function which returns the content of a socless vault
     # we expect it to be called as {vault( context.vault_id) }  and return the same value
     # that current vault:vault-id would return
-    # Essentially a recreation of
     return fetch_from_vault(vault_id, content_only=True)
 
 
@@ -75,3 +74,8 @@ custom_filters = {"maptostr": maptostr, **custom_functions}
 jinja_env.filters.update(custom_filters)
 # Register Custom Functions
 jinja_env.globals.update(custom_functions)
+
+
+def render_jinja_from_string(template_string: str, root_object: dict) -> Any:
+    template_obj = jinja_env.from_string(template_string)
+    return template_obj.render(context=root_object)

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -575,3 +575,21 @@ def test_socless_template_string_after_jinja_resolve():
 
     assert expected_resolved_param == resolved_parameter
     assert expected_resolved_param == socless_template_string(resolved_parameter, mock_context)
+
+
+def test_socless_template_string_after_jinja_resolve_multiple_templates():
+    string_parameter = "Hello {context.dict.safe_string}, {context.unicodelist}"
+    resolver = ParameterResolver(mock_context)
+    resolved_parameter = resolver.resolve_reference(string_parameter)
+
+    expected_resolved_param = """Hello Elliot Alderson, ['hello', 'world']"""
+
+    assert expected_resolved_param == resolved_parameter
+    assert expected_resolved_param == socless_template_string(resolved_parameter, mock_context)
+
+
+def test_socless_template_string_after_jinja_resolve_multiple_templates_if_one_is_malformed():
+    string_parameter = "Hello {context.dict.safe_string}, {context.dict.unicodelist}"
+    resolver = ParameterResolver(mock_context)
+    with pytest.raises(SoclessBootstrapError):
+        resolver.resolve_reference(string_parameter)

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -556,3 +556,15 @@ def test_maptostr():
     assert socless_template_string(
         "{context.unicodelist|maptostr}", mock_context
     ) == "{}".format(["hello", "world"])
+
+
+def test_socless_template_string_after_jinja_resolve():
+    resolver = ParameterResolver(mock_context)
+    string_parameter = "Hello {context.dict}"
+
+    resolved_parameter = resolver.resolve_reference(string_parameter)
+
+    expected_resolved_param = """Hello {'safe_string': 'Elliot Alderson', 'unsafe_string': "<script>alert('Elliot Alderson')</script>"}"""
+
+    assert expected_resolved_param == resolved_parameter
+    assert expected_resolved_param == socless_template_string(resolved_parameter, mock_context)

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -558,10 +558,17 @@ def test_maptostr():
     ) == "{}".format(["hello", "world"])
 
 
-def test_socless_template_string_after_jinja_resolve():
-    resolver = ParameterResolver(mock_context)
-    string_parameter = "Hello {context.dict}"
+def test_socless_template_string_invalid_template():
+    original_message = "Hello {code}"
+    assert (
+        socless_template_string(original_message, mock_context)
+        == original_message
+    )
 
+
+def test_socless_template_string_after_jinja_resolve():
+    string_parameter = "Hello {context.dict}"
+    resolver = ParameterResolver(mock_context)
     resolved_parameter = resolver.resolve_reference(string_parameter)
 
     expected_resolved_param = """Hello {'safe_string': 'Elliot Alderson', 'unsafe_string': "<script>alert('Elliot Alderson')</script>"}"""

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -69,6 +69,11 @@ def test_resolve_template_preformatted_fromjson():
     assert resolved == {'foo' : 'bar'}
 
 
+def test_resolve_template_preformatted_fromjson_invalid_json():
+    with pytest.raises(SoclessBootstrapError):
+        resolve_string_parameter("""{ '{"foo": "bar" : bas}' |fromjson}""", {})
+
+
 def test_ParameterResolver_resolve_reference(TestParamResolver):
     # Test with string value
     assert TestParamResolver.resolve_reference("Hello") == "Hello"

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -523,14 +523,16 @@ def test_safe_string():
 def test_unsafe_string():
     assert (
         socless_template_string("Hello {context.unsafe_string}", mock_context)
-        == "Hello &lt;script&gt;alert('Elliot Alderson')&lt;/script&gt;"
+        # == "Hello &lt;script&gt;alert('Elliot Alderson')&lt;/script&gt;"
+        == "Hello <script>alert('Elliot Alderson')</script>"
     )
 
 
 def test_dictionary_reference():
     assert (
         socless_template_string("Hello {context.dict}", mock_context)
-        == """Hello {'safe_string': 'Elliot Alderson', 'unsafe_string': "&lt;script&gt;alert('Elliot Alderson')&lt;/script&gt;"}"""
+        # == """Hello {'safe_string': 'Elliot Alderson', 'unsafe_string': "&lt;script&gt;alert('Elliot Alderson')&lt;/script&gt;"}"""
+        == """Hello {'safe_string': 'Elliot Alderson', 'unsafe_string': "<script>alert('Elliot Alderson')</script>"}"""
     )
 
 

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -102,6 +102,12 @@ def test_ParameterResolver_resolve_parameters(TestParamResolver):
     assert TestParamResolver.resolve_parameters(parameters) == {"firstname": "Sterling", "lastname": "Archer", "middlename": "Malory", "vault.txt": "this came from the vault", "vault.json": {'hello': 'world'}, "acquaintances": [{"firstname": "Malory", "lastname": "Archer"}]}
 
 
+def test_ParameterResolver_resolve_strings_with_invalid_jinja(TestParamResolver):
+    # Test with string value
+    test_string = "something {with something else.} and another thing."
+    assert TestParamResolver.resolve_reference(test_string) == test_string
+
+
 def test_ExecutionContext_init():
     # test ExecutionContext init to assert the execution_id is the same one as expected
     execution_id = gen_id()

--- a/tests/test_jinja.py
+++ b/tests/test_jinja.py
@@ -1,0 +1,51 @@
+# Copyright 2018 Twilio, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+import json, pytest
+from tests.conftest import *  # imports testing boilerplate
+from socless.jinja import fromjson, vault, jinja_env
+
+
+@pytest.fixture()
+def root_obj():
+    # setup root_obj for use in tesing TestParamResolver
+    return {
+        "artifacts": {
+            "event": {
+                "details": {
+                    "firstname": "Sterling",
+                    "middlename": "Malory",
+                    "lastname": "Archer",
+                    "vault_test": "vault:socless_vault_tests.txt",
+                }
+            }
+        }
+    }
+
+
+def test_raw_function_fromjson():
+    mock_json = {"test": "response", "foo": ["bar"], "baz": {"bang": "fizz"}}
+    stringified_json = json.dumps(mock_json)
+    assert mock_json == fromjson(stringified_json)
+
+
+def test_raw_function_vault():
+    content = vault("socless_vault_tests.txt")
+    assert content == "this came from the vault"
+
+
+def test_jinja_from_string_vault():
+    # single quotes are required to escape the . notation for jinja dict accessor
+    template = jinja_env.from_string("{vault('socless_vault_tests.txt')}")
+    content = template.render(context={})
+    assert content == "this came from the vault"


### PR DESCRIPTION
This PR adds jinja templating engine as the ParameterResolver for any strings passed to a SOCless Task via Parameters in `playbook.json`.

- Integrations no longer need to call `socless_template_string` to use the "my string is {context.x.x} " syntax.
- Prefer usage of `"{context.artifacts.event.details.username}"` vs. `"$.artifacts.event.details.username"` when referencing items in the SOCless global state

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
