### PR TITLE
add test for retrieving json from vault id with new jinja syntax

### DIFF
--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -65,6 +65,15 @@ def test_resolve_template_with_conversion():
     assert resolved == {'hello': 'world'}
 
 
+def test_resolve_template_with_conversion_as_context_syntax():
+    resolved = resolve_string_parameter("{context.results.Test_Step.file_id | vault | fromjson}", {
+        "results" : {
+            "Test_Step" : {"file_id": "socless_vault_tests.json"}
+        }
+    })
+    assert resolved == {'hello': 'world'}
+
+
 def test_resolve_template_preformatted_fromjson():
     resolved = resolve_string_parameter("""{ '{"foo": "bar"}' |fromjson}""", {})
     assert resolved == {'foo' : 'bar'}


### PR DESCRIPTION
<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
