### PR TITLE
Rewrite events.py so event & playbook models are well-defined 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+Socless Core Library
+===================
+
+The Socless Core library contains functions used by the Socless automation framework to bootstrap its core components and integrations.
+
+
+
+create_events call flow
+
+1. `create_events` calls `EventBatch().create_events`
+2. `EventBatch()` init ensures the event keys are the right types
+3. `EventBatch().create_events` says for each event in details list:
+   1.  format the event to a new structure and then call `EventCreator(new_event).create()`
+   2.  `EventBatch().execute_playbook()` - step 7
+4.  `EventCreator` init validates event key types
+5.  `EventCreator` `.create()` calls `.deduplicate()` which interacts with DEDUP_TABLE and mutates the event
+6.  `.create()` then formats the event and puts it into the EVENTS_TABLE
+7.  `EventBatch().execute_playbook()` 
+    1.  formats the playbook metadata (arn, investigation_id, input dict)
+    2.  puts an item in the results table
+    3.  starts stepFunctions with a subset of results item

--- a/README.md
+++ b/README.md
@@ -2,20 +2,3 @@ Socless Core Library
 ===================
 
 The Socless Core library contains functions used by the Socless automation framework to bootstrap its core components and integrations.
-
-
-
-create_events call flow
-
-1. `create_events` calls `EventBatch().create_events`
-2. `EventBatch()` init ensures the event keys are the right types
-3. `EventBatch().create_events` says for each event in details list:
-   1.  format the event to a new structure and then call `EventCreator(new_event).create()`
-   2.  `EventBatch().execute_playbook()` - step 7
-4.  `EventCreator` init validates event key types
-5.  `EventCreator` `.create()` calls `.deduplicate()` which interacts with DEDUP_TABLE and mutates the event
-6.  `.create()` then formats the event and puts it into the EVENTS_TABLE
-7.  `EventBatch().execute_playbook()` 
-    1.  formats the playbook metadata (arn, investigation_id, input dict)
-    2.  puts an item in the results table
-    3.  starts stepFunctions with a subset of results item

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,0 @@
-Socless Core Library
-===================
-
-The Socless Core library contains functions used by the Socless automation framework to bootstrap its core components and integrations.

--- a/socless/events.py
+++ b/socless/events.py
@@ -110,17 +110,17 @@ class InitialEvent:
         """TypeCheck the event attributes"""
         validate_iso_datetime(self.created_at)
         if not isinstance(self.details, dict):
-            raise Exception("Error: Supplied 'details' is not a dictionary")
+            raise TypeError("Error: Supplied 'details' is not a dictionary")
         if not isinstance(self.data_types, dict):
-            raise Exception("Error: Supplied 'data_types' is not a dictionary")
+            raise TypeError("Error: Supplied 'data_types' is not a dictionary")
         if not isinstance(self.event_meta, dict):
-            raise Exception("Error: Supplied 'event_meta' is not a dictionary")
+            raise TypeError("Error: Supplied 'event_meta' is not a dictionary")
         if not isinstance(self.event_type, str):
-            raise Exception("Error: Supplied 'event_type' is not a string")
+            raise TypeError("Error: Supplied 'event_type' is not a string")
         if not isinstance(self.playbook, str):
-            raise Exception("Error: Supplied Playbook is not a string")
+            raise TypeError("Error: Supplied Playbook is not a string")
         if not isinstance(self.dedup_keys, list):
-            raise Exception("Error: Supplied 'dedup_keys' field is not a list")
+            raise TypeError("Error: Supplied 'dedup_keys' field is not a list")
 
     @property
     def dedup_hash(self) -> str:
@@ -297,8 +297,9 @@ class CompleteEvent:
 
 def create_events(event_details: dict, context):
     """Deduplicate and start playbooks from an intial event or list of event details."""
-    # setup event_details format
+    # setup event_details formats
     event_details.setdefault("created_at", gen_datetimenow())
+    # convert "details" to a list of "details" objects (for backwards compatibility)
     if not isinstance(event_details["details"], list):
         event_details["details"] = [event_details["details"]]
 
@@ -316,15 +317,6 @@ def create_events(event_details: dict, context):
                     "event_meta": event_details.get("event_meta", {}),
                     "dedup_keys": event_details.get("dedup_keys", []),
                 }
-                # InitialEvent(
-                #     details=details_dict,
-                #     created_at=event_details["created_at"],
-                #     event_type=event_details["event_type"],
-                #     playbook=event_details["playbook"],
-                #     data_types=event_details.get("data_types", {}),
-                #     event_meta=event_details.get("event_meta", {}),
-                #     dedup_keys=event_details.get("dedup_keys", []),
-                # )
             )
         )
 

--- a/socless/events.py
+++ b/socless/events.py
@@ -14,10 +14,13 @@
 """
 Classes and modules for creating and managing events
 """
+from socless.models import EventTableItem, PlaybookArtifacts, PlaybookInput
+from socless.exceptions import SoclessEventsError, SoclessNotFoundError
+from typing import List, Optional
 from .logger import socless_log
 import os, boto3, simplejson as json, hashlib
-from datetime import datetime
-from .utils import gen_id, gen_datetimenow
+from dataclasses import dataclass, asdict
+from .utils import gen_id, gen_datetimenow, validate_iso_datetime
 
 
 EVENTS_TABLE = os.environ.get("SOCLESS_EVENTS_TABLE", "")
@@ -26,56 +29,101 @@ event_table = boto3.resource("dynamodb").Table(EVENTS_TABLE)
 dedup_table = boto3.resource("dynamodb").Table(DEDUP_TABLE)
 
 
-class EventCreator:
-    """Handles the creation of an Event"""
+def get_playbook_arn(playbook_name, lambda_context):
+    return "arn:aws:states:{region}:{accountid}:stateMachine:{stateMachineName}".format(
+        region=os.environ["AWS_REGION"],
+        accountid=lambda_context.invoked_function_arn.split(":")[4],
+        stateMachineName=playbook_name,
+    )
 
-    def __init__(self, event_info):
-        self.event_info = event_info
 
-        self.event_type = event_info.get("event_type")
-        if not self.event_type:
-            raise Exception("Error: event_type must be supplied")
+def setup_results_table_for_playbook(
+    execution_id: str, investigation_id: str, playbook_input_as_dict: dict
+):
+    results_table = boto3.resource("dynamodb").Table(
+        os.environ.get("SOCLESS_RESULTS_TABLE")
+    )
+    _ = results_table.put_item(
+        Item={
+            "execution_id": execution_id,
+            "datetime": gen_datetimenow(),
+            "investigation_id": investigation_id,
+            "results": playbook_input_as_dict,
+        }
+    )
 
-        self.created_at = event_info.get("created_at")
-        if not self.created_at:
-            self.created_at = gen_datetimenow()
-        else:
-            try:
-                datetime.strptime(self.created_at, "%Y-%m-%dT%H:%M:%S.%fZ")
-            except Exception:
-                raise Exception(
-                    "Error: Supplied 'created_at' field is not ISO8601 millisecond-precision string, shifted to UTC"
-                )
 
-        self.details = event_info.get("details", {})
+def get_investigation_id_from_dedup_table_or_raise_not_found(dedup_hash: str) -> str:
+    """Check dedup_table for an investigation_id using the dedup_hash.
+    Raises:
+        SoclessNotFoundError if dedup_table item is malformed or doesnt exist.
+    Logs a warning if a dedup_hash is found but doesn't contain any investigation_id.
+    """
+    _cached_dedup_hash = dedup_hash
+    key = {"dedup_hash": _cached_dedup_hash}
+    dedup_mapping = dedup_table.get_item(Key=key).get("Item")
+
+    if dedup_mapping:
+        try:
+            return dedup_mapping["current_investigation_id"]
+        except KeyError:
+            socless_log.warn(
+                "Item without 'current_investigation_id' found in dedup table",
+                key,
+            )
+            raise SoclessNotFoundError("No investigation_id found in dedup_mapping")
+    else:
+        raise SoclessNotFoundError("dedup_hash not found in dedup_table")
+
+
+def get_investigation_id_from_existing_open_event_or_raise_not_found(
+    current_investigation_id,
+) -> str:
+    current_investigation = event_table.get_item(
+        Key={"id": current_investigation_id}
+    ).get("Item")
+    if current_investigation and current_investigation["status_"] != "closed":
+        return current_investigation["investigation_id"]
+    else:
+        raise SoclessNotFoundError("No open investigation found")
+
+
+@dataclass
+class StartExecutionReport:
+    investigation_id: str
+    execution_id: str
+    playbook: str
+    statemachinearn: str
+    error: Optional[str]
+
+
+@dataclass
+class InitialEvent:
+    created_at: str
+    event_type: str
+    playbook: Optional[str]
+    details: dict
+    data_types: dict
+    event_meta: dict
+    dedup_keys: list
+
+    def __post_init__(self):
+        validate_iso_datetime(self.created_at)
         if not isinstance(self.details, dict):
             raise Exception("Error: Supplied 'details' is not a dictionary")
-
-        self.data_types = event_info.get("data_types", {})
         if not isinstance(self.data_types, dict):
             raise Exception("Error: Supplied 'data_types' is not a dictionary")
-
-        self.event_meta = event_info.get("event_meta", {})
         if not isinstance(self.event_meta, dict):
             raise Exception("Error: Supplied 'event_meta' is not a dictionary")
-
-        self.playbook = event_info.get("playbook", "")
+        if not isinstance(self.event_type, str):
+            raise Exception("Error: Supplied 'event_type' is not a string")
         if not isinstance(self.playbook, str):
             raise Exception("Error: Supplied Playbook is not a string")
-
-        self.dedup_keys = event_info.get("dedup_keys", [])
         if not isinstance(self.dedup_keys, list):
             raise Exception("Error: Supplied 'dedup_keys' field is not a list")
 
-        self._id = gen_id()
-
-        # Initialize with the assumption that the event is a new investigation
-        self.investigation_id = self._id
-        self.status_ = "open"
-        self.is_duplicate = False
-
     @property
-    def dedup_hash(self):
+    def dedup_hash(self) -> str:
         """Property that returns the deduplication hash.
 
         Using the keys in the 'dedup_keys' list, build a single string that
@@ -94,215 +142,211 @@ class EventCreator:
         dedup_hash = hashlib.md5(dedup_signature.encode("utf-8")).hexdigest()
         return dedup_hash
 
-    def deduplicate(self):
-        """Deduplicates an event, setting the is_duplicate and investigation_id attributes
-        Current deduplication algorithm is:
-            hexdigest of md5( event_type + sorted(dedup_values) )
+
+class EventMetadata:
+    def __init__(self):
+        new_id = gen_id()
+        self._id = new_id
+        self.investigation_id = new_id
+        self.execution_id = gen_id()
+        self.status_ = "open"
+        self.is_duplicate = False
+
+
+class CompleteEvent:
+    """A container for an event, its metadata, and methods to interact with the event.
+    Attributes:
+        `event` : InitialEvent class, contains specific event details
+        `metadata`: EventMetadata class, contains investigation_id, dedup status, etc.
+    """
+
+    def __init__(self, initial_event: InitialEvent) -> None:
+        """Methods:
+        `as_event_table_item`: returns formatted event data for input to events_table
+        `deduplicate_and_update_dedup_table`: check dedup_table & event_table to see if this event exists, mutate self.metadata and update dedup_table accordingly
+        `put_in_events_table`: put event in events_table (does NOT deuplicate automatically)
+        `start_playbook` :
         """
+        self.event: InitialEvent = initial_event
+        # init with assumption of not-duplicate EventMetadata
+        self.metadata = EventMetadata()
 
-        # Correct the assumption that the event is a new investigation if there is an open event currently mapped to the dedup hash
-        self._cached_dedup_hash = self.dedup_hash
-        dedup_mapping = dedup_table.get_item(
-            Key={"dedup_hash": self._cached_dedup_hash}
-        ).get("Item")
+    @property
+    def as_event_table_item(self):
+        return EventTableItem(
+            id=self.metadata._id,
+            investigation_id=self.metadata.investigation_id,
+            status_=self.metadata.status_,
+            is_duplicate=self.metadata.is_duplicate,
+            created_at=self.event.created_at,
+            data_types=self.event.data_types,
+            details=self.event.details,
+            event_type=self.event.event_type,
+            event_meta=self.event.event_meta,
+            playbook=self.event.playbook,
+        )
 
-        if dedup_mapping:
-            current_investigation_id = dedup_mapping.get("current_investigation_id")
-            if not current_investigation_id:
-                socless_log.warn(
-                    "unmapped dedup_hash detected in dedup table",
-                    {"dedup_hash": self._cached_dedup_hash},
+    def _deduplicate(self):
+        """Use InitialEvent and DynamoDB to mutate whether EventMetadata is duplicate or not.
+
+        This is not built into any `init` functions because some events may explicitly
+        opt out of deduplication depending on where they are created from
+        Notes:
+            Depends on dedup_table & event_table.
+        """
+        if not self.event.dedup_keys:
+            return
+        try:
+            # check if duplicate
+            temp_investigation_id = (
+                get_investigation_id_from_dedup_table_or_raise_not_found(
+                    self.event.dedup_hash
                 )
-                return
-            current_investigation = event_table.get_item(
-                Key={"id": current_investigation_id}
-            ).get("Item")
-            if current_investigation and current_investigation["status_"] != "closed":
-                self.investigation_id = current_investigation["investigation_id"]
-                self.status_ = "closed"
-                self.is_duplicate = True
-
-        return
-
-    def create(self):
-        """Create an event.
-
-        Check if event is duplicate, if not then add it to the dedup table.
-        """
-        # Deduplicate the event if there are dedup keys set
-        if self.dedup_keys:
-            self.deduplicate()
-            # Create/Update dedup_hash mapping if the event is an original
-            if not self.is_duplicate:
-                new_dedup_mapping = {
-                    "dedup_hash": self._cached_dedup_hash,
-                    "current_investigation_id": self.investigation_id,
-                }
-                dedup_table.put_item(Item=new_dedup_mapping)
-        else:
+            )
+            self.metadata.investigation_id = (
+                get_investigation_id_from_existing_open_event_or_raise_not_found(
+                    temp_investigation_id
+                )
+            )
+            self.metadata.status_ = "closed"
+            self.metadata.is_duplicate = True
+        except SoclessNotFoundError:
+            # event is not duplicate
             pass
 
-        # Create event entry and save it
-        event = {
-            "id": self._id,
-            "created_at": self.created_at,
-            "data_types": self.data_types,
-            "details": self.details,
-            "event_type": self.event_type,
-            "event_meta": self.event_meta,
-            "investigation_id": self.investigation_id,
-            "status_": self.status_,
-            "is_duplicate": self.is_duplicate,
-        }
-        if self.playbook:
-            event["playbook"] = self.playbook
-        event_table.put_item(Item=event)
-        return event
-
-
-class EventBatch:
-    """Creates a batch of events and executes the appropriate playbook"""
-
-    def __init__(self, event_batch, lambda_context):
-        """Initialize the EventBatch with data that is common to all events
-
-        Args:
-            event_batch (dict): A batch of events
-            lambda_context (obj): Lambda context object
-            dedup (bool): Toggle to enable/disable deduplication of events
+    def deduplicate_and_update_dedup_table(self):
+        """Check if event is duplicate, if not then add it to the dedup table.
+        Notes:
+            Depends on dedup_table & event_table.
         """
-        # Initialize properties
-        self.event_type = event_batch.get("event_type")
+        # Deduplicate the event if there are dedup keys set
+        if self.event.dedup_keys:
+            self._deduplicate()
+            # Create/Update dedup_hash mapping if the event is an original
+            if not self.metadata.is_duplicate:
+                new_dedup_mapping = {
+                    "dedup_hash": self.event.dedup_keys,
+                    "current_investigation_id": self.metadata.investigation_id,
+                }
+                dedup_table.put_item(Item=new_dedup_mapping)
 
-        self.created_at = event_batch.get("created_at")
-
-        self.details = event_batch.get("details", [{}])
-        for each in self.details:
-            if not isinstance(each, dict):
-                raise Exception("Error: Details must be a list of dictionaries")
-
-        self.data_types = event_batch.get("data_types", {})
-
-        self.event_meta = event_batch.get("event_meta", {})
-
-        self.playbook = event_batch.get("playbook", "")
-        if not isinstance(self.playbook, str):
-            raise Exception("Error: Supplied Playbook is not a string")
-
-        self.dedup_keys = event_batch.get("dedup_keys", [])
-        if not isinstance(self.dedup_keys, list):
-            raise Exception("Error: Supplied 'dedup_keys' field is not a list")
-
-        self.lambda_context = lambda_context
-
-    def create_events(self):
+    def put_in_events_table(self):
+        """Combine event and metadata, then input into socless event_table.
+        NOTE: does not check if event is duplicate
         """
-        Create events
+        event_table_item = self.as_event_table_item
+        event_table.put_item(Item=event_table_item.__dict__)
+
+    def start_playbook(
+        self, playbook_arn, stepfunctions_client
+    ) -> StartExecutionReport:
+        """Create playbook input, save data to results_table & attempt to start execution
+        NOTE: depends on results_table
         """
-        execution_statuses = []
-
-        for detection in self.details:
-            event_info = {}
-            event_info["created_at"] = self.created_at
-            event_info["data_types"] = self.data_types
-            event_info["details"] = detection
-            event_info["event_type"] = self.event_type
-            event_info["event_meta"] = self.event_meta
-            event_info["dedup_keys"] = self.dedup_keys
-            if self.playbook:
-                event_info["playbook"] = self.playbook
-
-            event = EventCreator(event_info).create()
-            # Trigger execution of a playbook if playbook was supplied
-            if self.playbook:
-                execution_statuses.append(
-                    self.execute_playbook(event, event["investigation_id"])
-                )
-
-        #! FIX: Will always return true, message is a list of individual
-        #! playbook responses that may be true or false (error) responses
-        return {"status": True, "message": execution_statuses}
-
-    def execute_playbook(self, entry, investigation_id=""):
-        """Execute a playbook for a SOCless event.
-        Args:
-            entry (dict): The event details
-            investigation_id (str): The investigation_id to use
-            playbook (str): The name of the playbook to execute
-        Returns:
-            dict: The execution_id, investigation_id and a status indicating if the playbook
-                execution request was successful
-        """
-        meta = {"investigation_id": investigation_id, "playbook": self.playbook}
-        if not investigation_id:
-            investigation_id = gen_id()
-        RESULTS_TABLE = os.environ.get("SOCLESS_RESULTS_TABLE")
-        playbook_input = {"artifacts": {}, "results": {}, "errors": {}}
-        playbook_arn = "arn:aws:states:{region}:{accountid}:stateMachine:{stateMachineName}".format(
-            region=os.environ["AWS_REGION"],
-            accountid=self.lambda_context.invoked_function_arn.split(":")[4],
-            stateMachineName=self.playbook,
+        playbook_input = PlaybookInput(
+            execution_id=self.metadata.execution_id,
+            artifacts=PlaybookArtifacts(
+                execution_id=self.metadata.execution_id, event=self.as_event_table_item
+            ),
+            results={},
+            errors={},
         )
-        execution_id = gen_id()
-        playbook_input["artifacts"]["event"] = entry
-        playbook_input["artifacts"]["execution_id"] = execution_id
-        results_table = boto3.resource("dynamodb").Table(RESULTS_TABLE)
-        _ = results_table.put_item(
-            Item={
-                "execution_id": execution_id,
-                "datetime": gen_datetimenow(),
-                "investigation_id": investigation_id,
-                "results": playbook_input,
-            }
+        playbook_input_as_dict = asdict(playbook_input)
+
+        setup_results_table_for_playbook(
+            self.metadata.execution_id,
+            self.metadata.investigation_id,
+            playbook_input_as_dict,
         )
-        stepfunctions = boto3.client("stepfunctions")
+
+        report = StartExecutionReport(
+            investigation_id=self.metadata.investigation_id,
+            playbook=str(self.event.playbook),
+            statemachinearn=playbook_arn,
+            execution_id=self.metadata.execution_id,
+            error="",
+        )
         try:
-            _ = stepfunctions.start_execution(
-                name=execution_id,
+            _ = stepfunctions_client.start_execution(
+                name=self.metadata.execution_id,
                 stateMachineArn=playbook_arn,
-                input=json.dumps(
-                    {
-                        "execution_id": execution_id,
-                        "artifacts": playbook_input["artifacts"],
-                    }
-                ),
+                input=json.dumps(playbook_input_as_dict),
             )
-            socless_log.info(
-                "Playbook execution started",
-                dict(
-                    meta,
-                    **{"statemachinearn": playbook_arn, "execution_id": execution_id},
-                ),
-            )
+            socless_log.info("Playbook execution started", report.__dict__)
         except Exception as e:
+            report.error = str(e)
             socless_log.error(
                 "Failed to start statemachine execution",
-                dict(
-                    meta,
-                    **{
-                        "statemachinearn": playbook_arn,
-                        "execution_id": execution_id,
-                        "error": f"{e}",
-                    },
-                ),
+                report.__dict__,
             )
-            return {"status": False, "message": f"Error: {e}"}
-        return {
-            "status": True,
-            "message": {
-                "execution_id": execution_id,
-                "investigation_id": investigation_id,
-            },
-        }
+        return report
 
 
-def create_events(event_details, context):
-    """Use the EventBatch class to create events
-    Args:
-        event_details (dict): The details of the events
-        context (obj): The Lambda context object
-    Returns:
-        dict containing the execution ids of the created events
-    """
-    event_batch = EventBatch(event_details, context)
-    return event_batch.create_events()
+def create_events(event_details: dict, context):
+    """Deduplicate and start playbooks from an intial event or list of event details."""
+    event_details.setdefault("created_at", gen_datetimenow())
+
+    # format events from list or single details dict
+    events_list: List[InitialEvent] = []
+    if isinstance(event_details["details"], list):
+        for details_dict in event_details["details"]:
+            events_list.append(
+                InitialEvent(
+                    details=details_dict,
+                    created_at=event_details["created_at"],
+                    event_type=event_details["event_type"],
+                    playbook=event_details["playbook"],
+                    data_types=event_details["data_types"],
+                    event_meta=event_details["event_meta"],
+                    dedup_keys=event_details["dedup_keys"],
+                )
+            )
+    else:
+        events_list.append(
+            InitialEvent(
+                details=event_details["details"],
+                created_at=event_details["created_at"],
+                event_type=event_details["event_type"],
+                playbook=event_details["playbook"],
+                data_types=event_details["data_types"],
+                event_meta=event_details["event_meta"],
+                dedup_keys=event_details["dedup_keys"],
+            )
+        )
+
+    stepfunctions_client = boto3.client("stepfunctions")
+    playbook_arn = get_playbook_arn(event_details["playbook"], context)
+    execution_reports: List[StartExecutionReport] = []
+    for event in events_list:
+        complete_event = CompleteEvent(initial_event=event)
+        complete_event.deduplicate_and_update_dedup_table()
+        complete_event.put_in_events_table()
+        exec_report = complete_event.start_playbook(playbook_arn, stepfunctions_client)
+        execution_reports.append(exec_report)
+
+    # check for failures
+    failures = [report for report in execution_reports if report.error]
+    if len(failures) > 0:
+        raise SoclessEventsError(
+            f"{len(failures)} of {len(execution_reports)} events failed to start playbooks.\n Failure Reports: \n {failures}"
+        )
+
+
+def validate_event(event):
+    """Ensure event contains the necessary keys with correct types."""
+    try:
+        if not event["event_type"]:
+            raise Exception("Error: event_type must be supplied")
+
+        if not isinstance(event["details"], dict):
+            raise Exception("Error: Supplied 'details' is not a dictionary")
+        if not isinstance(event["data_types"], dict):
+            raise Exception("Error: Supplied 'data_types' is not a dictionary")
+        if not isinstance(event["event_meta"], dict):
+            raise Exception("Error: Supplied 'event_meta' is not a dictionary")
+        if not isinstance(event["playbook"], str):
+            raise Exception("Error: Supplied Playbook is not a string")
+        if not isinstance(event["dedup_keys"], list):
+            raise Exception("Error: Supplied 'dedup_keys' field is not a list")
+    except KeyError as e:
+        raise SoclessEventsError(f"Unable to create socless event - Missing Key: {e}")

--- a/socless/exceptions.py
+++ b/socless/exceptions.py
@@ -21,5 +21,13 @@ class SoclessException(Exception):
     pass
 
 
+class SoclessNotFoundError(Exception):
+    pass
+
+
+class SoclessEventsError(Exception):
+    pass
+
+
 class SoclessBootstrapError(Exception):
     pass

--- a/socless/models.py
+++ b/socless/models.py
@@ -1,0 +1,64 @@
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class EventTableItem:
+    id: str
+    investigation_id: str
+    status_: str
+    is_duplicate: bool
+    created_at: str
+    event_type: str
+    playbook: Optional[str]
+    details: dict
+    data_types: dict
+    event_meta: dict
+
+
+@dataclass
+class DedupTableItem:
+    current_investigation_id: str
+    dedup_hash: str
+
+
+@dataclass
+class MessageResponsesTableItem:
+    message_id: str  # PK : callback id for message responses
+    await_token: str  # used to start next step in step_functions
+    receiver: str  # step_functions step name
+    fulfilled: bool  # has await_token been used
+    message: str  # message sent to user while waiting for their response
+    execution_id: str
+    investigation_id: str
+    datetime: str
+
+
+@dataclass
+class PlaybookArtifacts:
+    event: EventTableItem
+    execution_id: str
+
+
+@dataclass
+class PlaybookInput:
+    execution_id: str
+    artifacts: PlaybookArtifacts
+    results: dict
+    errors: dict
+
+
+@dataclass
+class StateConfig:
+    Name: str
+    Parameters: dict
+
+
+@dataclass
+class SoclessContext:
+    execution_id: Optional[str] = None
+    artifacts: Optional[dict] = None
+    results: Optional[dict] = None
+    errors: Optional[dict] = field(default_factory=dict)
+    task_token: Optional[str] = None
+    state_name: Optional[str] = None

--- a/socless/models.py
+++ b/socless/models.py
@@ -46,19 +46,3 @@ class PlaybookInput:
     artifacts: PlaybookArtifacts
     results: dict
     errors: dict
-
-
-@dataclass
-class StateConfig:
-    Name: str
-    Parameters: dict
-
-
-@dataclass
-class SoclessContext:
-    execution_id: Optional[str] = None
-    artifacts: Optional[dict] = None
-    results: Optional[dict] = None
-    errors: Optional[dict] = field(default_factory=dict)
-    task_token: Optional[str] = None
-    state_name: Optional[str] = None

--- a/socless/utils.py
+++ b/socless/utils.py
@@ -41,6 +41,16 @@ def gen_datetimenow():
     return datetime.utcnow().isoformat() + "Z"
 
 
+def validate_iso_datetime(iso_datetime: str):
+    """Raises Exception if not correct format"""
+    try:
+        datetime.strptime(iso_datetime, "%Y-%m-%dT%H:%M:%S.%fZ")
+    except Exception:
+        raise Exception(
+            "Error: Supplied 'created_at' field is not ISO8601 millisecond-precision string, shifted to UTC"
+        )
+
+
 def convert_empty_strings_to_none(nested_dict):
     converted_dict = {}
     if isinstance(nested_dict, dict):

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -11,15 +11,24 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License
+import dataclasses
+from socless.models import EventTableItem
 from tests.conftest import *  # imports testing boilerplate
 from .helpers import MockLambdaContext, dict_to_item
 import json, os
 from copy import deepcopy
 import pytest
 from moto import mock_stepfunctions, mock_sts, mock_iam
-from socless.utils import convert_empty_strings_to_none
+from socless.utils import convert_empty_strings_to_none, gen_datetimenow
 
-from socless.events import EventCreator, EventBatch
+from socless.events import (
+    InitialEvent,
+    CompleteEvent,
+    create_events,
+    get_investigation_id_from_dedup_table,
+    get_investigation_id_from_existing_unclosed_event,
+    get_playbook_arn,
+)
 
 account_id = os.environ["MOTO_ACCOUNT_ID"]
 
@@ -39,393 +48,503 @@ iam_trust_policy_document = {
     },
 }
 
-MOCK_EVENT_BATCH = {
+MOCK_EVENT = {
+    "created_at": gen_datetimenow(),
     "event_type": "ParamsToStateMachineTester",
+    "details": {"username": "ubalogun", "type": "user", "id": "1"},
+    "data_types": {},
+    "event_meta": {},
+    "playbook": "ParamsToStateMachineTester",
+    "dedup_keys": ["username"],
+}
+
+MOCK_EVENT_BATCH = {
+    **MOCK_EVENT,
     "details": [
         {"username": "ubalogun", "type": "user", "id": "1"},
         {"username": "ubalogun", "type": "user", "id": "2"},
         {"username": "ubalogun", "type": "user", "id": "1"},
     ],
-    "playbook": "ParamsToStateMachineTester",
     "dedup_keys": ["username", "id"],
 }
 
-MOCK_EVENT = {
-    "event_info": "",
-    "event_type": "ParamsToStateMachineTester",
-    "details": {"username": "ubalogun", "type": "user", "id": "1"},
-    "data_types": {},
-    "event_meta": {},
-    "playbook": "",
-    "dedup_keys": ["username"],
-}
-
 DEDUP_HASH_FOR_MOCK_EVENT = "0caa90ad7b7fc101b90a8ce0f9638eb9"
+DEDUP_HASH_FOR_EVENT_DUPLICATE_TEST = "a88c7944f007e92a7776bd3550c39265"
 MOCK_INVESTIGATION_ID = "mock_investigation_id"
+MOCK_PLAYBOOK_NAME = "ParamsToStateMachineTester"
 
 
-def test_EventCreator_init_happy():
-    event_details = EventCreator(MOCK_EVENT)
+def setup_for_step_functions_test(playbook_name: str):
+    iam_client = boto3.client("iam", region_name="us-east-1")
+    iam_role_arn = iam_client.role_arn = iam_client.create_role(
+        RoleName="new-user",
+        AssumeRolePolicyDocument=json.dumps(iam_trust_policy_document),
+    )["Role"]["Arn"]
 
-    assert event_details.event_type == MOCK_EVENT["event_type"]
-    assert event_details.details == MOCK_EVENT["details"]
-    assert event_details.data_types == {}
-    assert event_details.dedup_keys == MOCK_EVENT["dedup_keys"]
-    assert event_details.event_meta == {}
-    assert event_details.playbook == MOCK_EVENT["playbook"]
-
-
-def test_EventCreator_init_fails_on_invalid_date_format():
-    edited_event_data = deepcopy(MOCK_EVENT)
-    edited_event_data["created_at"] = "bad_date"
-
-    with pytest.raises(Exception):
-        event_details = EventCreator(edited_event_data)
+    sf_client = boto3.client("stepfunctions")
+    sm = sf_client.create_state_machine(
+        name=playbook_name,
+        definition=str(playbook_definition),
+        roleArn=iam_role_arn,
+    )
+    return sf_client
 
 
-def test_EventCreator_init_fails_on_invalid_event_type():
-    edited_event_data = deepcopy(MOCK_EVENT)
-    edited_event_data["event_type"] = ""
-
-    with pytest.raises(Exception):
-        event_details = EventCreator(edited_event_data)
+def test_InitialEvent_with_normal_data():
+    event = InitialEvent(**MOCK_EVENT)
+    assert event.dedup_hash == "0caa90ad7b7fc101b90a8ce0f9638eb9"
 
 
-def test_EventCreator_init_fails_on_invalid_details():
-    edited_event_data = deepcopy(MOCK_EVENT)
-    edited_event_data["details"] = ""
+def test_CompleteEvent_as_event_table_item():
+    initial_event = InitialEvent(**MOCK_EVENT)
+    complete_event = CompleteEvent(initial_event)
+    item = complete_event.as_event_table_item
 
-    with pytest.raises(Exception):
-        event_details = EventCreator(edited_event_data)
-
-
-def test_EventCreator_init_fails_when_invalid_data_types():
-    edited_event_data = deepcopy(MOCK_EVENT)
-    edited_event_data["data_types"] = ""
-
-    with pytest.raises(Exception):
-        event_details = EventCreator(edited_event_data)
+    assert item.id == complete_event.metadata._id
+    assert isinstance(item, EventTableItem)
+    assert item.__dict__ == dataclasses.asdict(item)
 
 
-def test_EventCreator_init_fails_when_details_is_not_dict():
-    edited_event_data = deepcopy(MOCK_EVENT)
-    edited_event_data["details"] = []
+def test_CompleteEvent__deduplicate():
+    # setup duplicate
+    client = boto3.client("dynamodb")
+    client.put_item(
+        TableName=os.environ["SOCLESS_DEDUP_TABLE"],
+        Item=dict_to_item(
+            {
+                "dedup_hash": DEDUP_HASH_FOR_MOCK_EVENT,
+                "current_investigation_id": MOCK_INVESTIGATION_ID,
+            },
+            convert_root=False,
+        ),
+    )
+    client.put_item(
+        TableName=os.environ["SOCLESS_EVENTS_TABLE"],
+        Item=dict_to_item(
+            {
+                "id": MOCK_INVESTIGATION_ID,
+                "investigation_id": "already_running_id",
+                "status_": "open",
+            },
+            convert_root=False,
+        ),
+    )
 
-    with pytest.raises(Exception):
-        event_details = EventCreator(edited_event_data)
+    # test _deduplicate()
+    complete_event = CompleteEvent(**MOCK_EVENT)
+    complete_event._deduplicate()
+    assert complete_event.metadata.status_ == "closed"
+    assert complete_event.metadata.is_duplicate
+    assert complete_event.metadata.investigation_id == "already_running_id"
+
+    #     event.deduplicate()
 
 
-#! this should fail, need to make changes to events.py so this fails
-# def test_EventCreator_fails_when_details_is_empty_dict():
+#     assert event.status_ == "open"
+#     assert event.is_duplicate == False
+
+
+@mock_stepfunctions
+@mock_iam
+def test_CompleteEvent_start_playbook():
+    # setup playbook
+    sf_client = setup_for_step_functions_test(MOCK_PLAYBOOK_NAME)
+
+    # test
+    initial_event = InitialEvent(**MOCK_EVENT)
+    complete_event = CompleteEvent(initial_event)
+
+    playbook_arn = get_playbook_arn(complete_event.event.playbook, MockLambdaContext())
+    complete_event.deduplicate_and_update_dedup_table()
+    complete_event.put_in_events_table()
+    exec_report = complete_event.start_playbook(playbook_arn, sf_client)
+
+    assert not exec_report.error
+
+
+@mock_stepfunctions
+@mock_iam
+def test_create_events():
+    # setup playbook
+    _ = setup_for_step_functions_test(MOCK_PLAYBOOK_NAME)
+
+    results = create_events(event_details=MOCK_EVENT, context=MockLambdaContext())
+    assert (
+        results["events"][0]["metadata"]["investigation_id"]
+        == results["execution_reports"][0]["investigation_id"]
+    )
+
+
+@mock_stepfunctions
+@mock_iam
+def test_create_events_with_multiple_details_and_duplicates():
+    # setup playbook
+    _ = setup_for_step_functions_test(MOCK_PLAYBOOK_NAME)
+
+    results = create_events(event_details=MOCK_EVENT_BATCH, context=MockLambdaContext())
+    assert (
+        results["events"][0]["metadata"]["investigation_id"]
+        == results["execution_reports"][0]["investigation_id"]
+    )
+    assert len(results["events"]) == len(results["execution_reports"])
+
+
+# def test_EventCreator_init_happy():
+#     event_details = EventCreator(MOCK_EVENT)
+
+#     assert event_details.event_type == MOCK_EVENT["event_type"]
+#     assert event_details.details == MOCK_EVENT["details"]
+#     assert event_details.data_types == {}
+#     assert event_details.dedup_keys == MOCK_EVENT["dedup_keys"]
+#     assert event_details.event_meta == {}
+#     assert event_details.playbook == MOCK_EVENT["playbook"]
+
+
+# def test_EventCreator_init_fails_on_invalid_date_format():
 #     edited_event_data = deepcopy(MOCK_EVENT)
-#     edited_event_data['details'] = {}
+#     edited_event_data["created_at"] = "bad_date"
 
 #     with pytest.raises(Exception):
 #         event_details = EventCreator(edited_event_data)
 
 
-def test_EventCreator_init_fails_on_invalid_event_meta():
-    edited_event_data = deepcopy(MOCK_EVENT)
-    edited_event_data["event_meta"] = ""
-
-    with pytest.raises(Exception):
-        event_details = EventCreator(edited_event_data)
-
-
-def test_EventCreator_init_fails_on_invalid_playbook():
-    edited_event_data = deepcopy(MOCK_EVENT)
-    edited_event_data["playbook"] = 1234
-
-    with pytest.raises(Exception):
-        event_details = EventCreator(edited_event_data)
-
-
-def test_EventCreator_init_fails_when_dedup_keys_not_a_list():
-    edited_event_data = deepcopy(MOCK_EVENT)
-    edited_event_data["dedup_keys"] = "key_to_dedupe"
-
-    with pytest.raises(Exception):
-        event_details = EventCreator(edited_event_data)
-
-
-def test_EventCreator_dedup_hash_is_correct():
-    event = EventCreator(MOCK_EVENT)
-    assert event.dedup_hash == DEDUP_HASH_FOR_MOCK_EVENT
-
-
-def test_EventCreator_dedup_hash_fails_when_dedup_keys_do_not_match_any_details():
-    edited_mock_event = deepcopy(MOCK_EVENT)
-    edited_mock_event["dedup_keys"] = ["invalid_key"]
-
-    event = EventCreator(edited_mock_event)
-    with pytest.raises(KeyError):
-        event.dedup_hash
-
-
-def test_deduplicate_unique():
-    event = EventCreator(MOCK_EVENT)
-    event.deduplicate()
-    pass
-
-
-def test_deduplicate_is_duplicate():
-    #  Setup tables for this event
-    client = boto3.client("dynamodb")
-    client.put_item(
-        TableName=os.environ["SOCLESS_DEDUP_TABLE"],
-        Item=dict_to_item(
-            {
-                "dedup_hash": DEDUP_HASH_FOR_MOCK_EVENT,
-                "current_investigation_id": MOCK_INVESTIGATION_ID,
-            },
-            convert_root=False,
-        ),
-    )
-    client.put_item(
-        TableName=os.environ["SOCLESS_EVENTS_TABLE"],
-        Item=dict_to_item(
-            {
-                "id": MOCK_INVESTIGATION_ID,
-                "investigation_id": "already_running_id",
-                "status_": "open",
-            },
-            convert_root=False,
-        ),
-    )
-
-    event = EventCreator(MOCK_EVENT)
-    event.deduplicate()
-    assert event.is_duplicate == True
-    assert event.status_ == "closed"
-    assert event.investigation_id == "already_running_id"
-
-
-def test_deduplicate_is_duplicate_status_closed():
-    #  Setup tables for this event
-    client = boto3.client("dynamodb")
-    client.put_item(
-        TableName=os.environ["SOCLESS_DEDUP_TABLE"],
-        Item=dict_to_item(
-            {
-                "dedup_hash": DEDUP_HASH_FOR_MOCK_EVENT,
-                "current_investigation_id": MOCK_INVESTIGATION_ID,
-            },
-            convert_root=False,
-        ),
-    )
-    client.put_item(
-        TableName=os.environ["SOCLESS_EVENTS_TABLE"],
-        Item=dict_to_item(
-            {
-                "id": MOCK_INVESTIGATION_ID,
-                "investigation_id": "already_running_id",
-                "status_": "closed",
-            },
-            convert_root=False,
-        ),
-    )
-
-    event = EventCreator(MOCK_EVENT)
-    event.deduplicate()
-    assert event.is_duplicate == False
-    assert event.status_ == "open"
-
-
-def test_deduplicate_is_duplicate_no_investigation_id():
-    #  Setup dedup_hash for this event (without investigation id)
-    client = boto3.client("dynamodb")
-    client.put_item(
-        TableName=os.environ["SOCLESS_DEDUP_TABLE"],
-        Item=dict_to_item(
-            {"dedup_hash": DEDUP_HASH_FOR_MOCK_EVENT}, convert_root=False
-        ),
-    )
-
-    # investigation_id NOT saved in dedup table, not duplicate
-    event = EventCreator(MOCK_EVENT)
-    event.deduplicate()
-    assert event.status_ == "open"
-    assert event.is_duplicate == False
-
-
-def test_deduplicate_is_unique():
-    event = EventCreator(MOCK_EVENT)
-    event.deduplicate()
-    assert event.status_ == "open"
-    assert event.is_duplicate == False
+# def test_EventCreator_init_fails_on_invalid_event_type():
+#     edited_event_data = deepcopy(MOCK_EVENT)
+#     edited_event_data["event_type"] = ""
 
+#     with pytest.raises(Exception):
+#         event_details = EventCreator(edited_event_data)
 
-def test_EventCreator_create():
-    event = EventCreator(MOCK_EVENT)
-
-    created_event = event.create()
-
-    # check dedup table
-    dedup_table = boto3.resource("dynamodb").Table(os.environ["SOCLESS_DEDUP_TABLE"])
-    dedup_mapping = dedup_table.get_item(Key={"dedup_hash": DEDUP_HASH_FOR_MOCK_EVENT})[
-        "Item"
-    ]
-
-    assert (
-        dedup_mapping["current_investigation_id"] == created_event["investigation_id"]
-    )
-    assert event.details == created_event["details"]
-    assert event.created_at == created_event["created_at"]
-
-
-def test_EventCreator_create_duplicate():
-    #  Setup tables for this event
-    client = boto3.client("dynamodb")
-    client.put_item(
-        TableName=os.environ["SOCLESS_DEDUP_TABLE"],
-        Item=dict_to_item(
-            {
-                "dedup_hash": DEDUP_HASH_FOR_MOCK_EVENT,
-                "current_investigation_id": MOCK_INVESTIGATION_ID,
-            },
-            convert_root=False,
-        ),
-    )
-    client.put_item(
-        TableName=os.environ["SOCLESS_EVENTS_TABLE"],
-        Item=dict_to_item(
-            {
-                "id": MOCK_INVESTIGATION_ID,
-                "investigation_id": "already_running_id",
-                "status_": "open",
-            },
-            convert_root=False,
-        ),
-    )
-
-    edited_event = deepcopy(MOCK_EVENT)
-    edited_event["dedup_keys"] = ["username"]
-
-    event = EventCreator(edited_event)
-    created_event = event.create()
-    assert created_event["is_duplicate"] == True
-
-
-def test_EventBatch():
-    batched_event = EventBatch(MOCK_EVENT_BATCH, MockLambdaContext())
-
-    assert batched_event.event_type == MOCK_EVENT_BATCH["event_type"]
-    assert batched_event.created_at == None  # created_at not supplied in mock
-    assert batched_event.details == MOCK_EVENT_BATCH["details"]
-    assert batched_event.data_types == {}  # created_at not supplied in mock
-    assert batched_event.dedup_keys == MOCK_EVENT_BATCH["dedup_keys"]
-    assert batched_event.event_meta == {}
-    assert batched_event.playbook == MOCK_EVENT_BATCH["playbook"]
-
-
-def test_EventBatch_missing_details():
-    bad_mock_event_batch = deepcopy(MOCK_EVENT_BATCH)
-    del bad_mock_event_batch["details"]
-    del bad_mock_event_batch["playbook"]
-
-    batched_event = EventBatch(bad_mock_event_batch, MockLambdaContext())
-
-    assert batched_event.playbook == ""
-    assert batched_event.details == [{}]
-
 
-def test_EventBatch_invalid_details_type():
-    bad_mock_event_batch = deepcopy(MOCK_EVENT_BATCH)
-    bad_mock_event_batch["details"] = "bad_arg"
-
-    with pytest.raises(Exception):
-        batched_event = EventBatch(bad_mock_event_batch, MockLambdaContext())
-
-
-def test_EventBatch_invalid_playbook_type():
-    bad_mock_event_batch = deepcopy(MOCK_EVENT_BATCH)
-    bad_mock_event_batch["playbook"] = ["bad_arg"]
-
-    with pytest.raises(Exception):
-        batched_event = EventBatch(bad_mock_event_batch, MockLambdaContext())
-
-
-def test_EventBatch_fails_on_invalid_type_for_dedup_keys():
-    bad_mock_event_batch = deepcopy(MOCK_EVENT_BATCH)
-    bad_mock_event_batch["dedup_keys"] = "bad_arg_type"
-
-    with pytest.raises(Exception):
-        batched_event = EventBatch(bad_mock_event_batch, MockLambdaContext())
-
-
-@mock_stepfunctions
-@mock_sts
-@mock_iam
-def test_EventBatch_execute_playbook():
-    # setup playbook
-    iam_client = boto3.client("iam", region_name="us-east-1")
-    sts_client = boto3.client("sts", region_name="us-east-1")
-    iam_role_name = "new-user"
-    iam_role_arn = iam_client.role_arn = iam_client.create_role(
-        RoleName=iam_role_name,
-        AssumeRolePolicyDocument=json.dumps(iam_trust_policy_document),
-    )["Role"]["Arn"]
-
-    client = boto3.client("stepfunctions")
-    sm = client.create_state_machine(
-        name="ParamsToStateMachineTester",
-        definition=str(playbook_definition),
-        roleArn=iam_role_arn,
-    )
-
-    batched_event = EventBatch(MOCK_EVENT_BATCH, MockLambdaContext())
-    result = batched_event.execute_playbook(convert_empty_strings_to_none(MOCK_EVENT))
-
-    assert result["status"] == True
-    assert isinstance(result["message"]["execution_id"], str)
-    assert isinstance(result["message"]["investigation_id"], str)
-
-
-def test_EventBatch_execute_playbook_failure():
-    edited_event = deepcopy(MOCK_EVENT_BATCH)
-    edited_event["playbook"] = "bad_playbook"
-
-    batched_event = EventBatch(edited_event, MockLambdaContext())
-    result = batched_event.execute_playbook(convert_empty_strings_to_none(MOCK_EVENT))
-
-    assert result["status"] == False
-
-
-@mock_stepfunctions
-@mock_sts
-@mock_iam
-def test_EventBatch_create_events():
-    # setup playbook
-    iam_client = boto3.client("iam", region_name="us-east-1")
-    sts_client = boto3.client("sts", region_name="us-east-1")
-    iam_role_name = "new-user"
-    iam_role_arn = iam_client.role_arn = iam_client.create_role(
-        RoleName=iam_role_name,
-        AssumeRolePolicyDocument=json.dumps(iam_trust_policy_document),
-    )["Role"]["Arn"]
-
-    client = boto3.client("stepfunctions")
-    sm = client.create_state_machine(
-        name="ParamsToStateMachineTester",
-        definition=str(playbook_definition),
-        roleArn=iam_role_arn,
-    )
-
-    batched_event = EventBatch(MOCK_EVENT_BATCH, MockLambdaContext())
-
-    result = batched_event.create_events()
-
-    #! FIX: result['status'] is always true, message is a list of individual
-    #! playbook responses that may be true or false (error) responses
-    assert result["status"] == True
-
-    assert result["message"][0]["status"] == True
-    assert result["message"][1]["status"] == True
-
-
-def test_create_events():
-    from socless.events import create_events
-
-    create_events_result = create_events(MOCK_EVENT_BATCH, MockLambdaContext())
-
-    assert create_events_result["status"] == True
+# def test_EventCreator_init_fails_on_invalid_details():
+#     edited_event_data = deepcopy(MOCK_EVENT)
+#     edited_event_data["details"] = ""
+
+#     with pytest.raises(Exception):
+#         event_details = EventCreator(edited_event_data)
+
+
+# def test_EventCreator_init_fails_when_invalid_data_types():
+#     edited_event_data = deepcopy(MOCK_EVENT)
+#     edited_event_data["data_types"] = ""
+
+#     with pytest.raises(Exception):
+#         event_details = EventCreator(edited_event_data)
+
+
+# def test_EventCreator_init_fails_when_details_is_not_dict():
+#     edited_event_data = deepcopy(MOCK_EVENT)
+#     edited_event_data["details"] = []
+
+#     with pytest.raises(Exception):
+#         event_details = EventCreator(edited_event_data)
+
+
+# #! this should fail, need to make changes to events.py so this fails
+# # def test_EventCreator_fails_when_details_is_empty_dict():
+# #     edited_event_data = deepcopy(MOCK_EVENT)
+# #     edited_event_data['details'] = {}
+
+# #     with pytest.raises(Exception):
+# #         event_details = EventCreator(edited_event_data)
+
+
+# def test_EventCreator_init_fails_on_invalid_event_meta():
+#     edited_event_data = deepcopy(MOCK_EVENT)
+#     edited_event_data["event_meta"] = ""
+
+#     with pytest.raises(Exception):
+#         event_details = EventCreator(edited_event_data)
+
+
+# def test_EventCreator_init_fails_on_invalid_playbook():
+#     edited_event_data = deepcopy(MOCK_EVENT)
+#     edited_event_data["playbook"] = 1234
+
+#     with pytest.raises(Exception):
+#         event_details = EventCreator(edited_event_data)
+
+
+# def test_EventCreator_init_fails_when_dedup_keys_not_a_list():
+#     edited_event_data = deepcopy(MOCK_EVENT)
+#     edited_event_data["dedup_keys"] = "key_to_dedupe"
+
+#     with pytest.raises(Exception):
+#         event_details = EventCreator(edited_event_data)
+
+
+# def test_EventCreator_dedup_hash_is_correct():
+#     event = EventCreator(MOCK_EVENT)
+#     assert event.dedup_hash == DEDUP_HASH_FOR_MOCK_EVENT
+
+
+# def test_EventCreator_dedup_hash_fails_when_dedup_keys_do_not_match_any_details():
+#     edited_mock_event = deepcopy(MOCK_EVENT)
+#     edited_mock_event["dedup_keys"] = ["invalid_key"]
+
+#     event = EventCreator(edited_mock_event)
+#     with pytest.raises(KeyError):
+#         event.dedup_hash
+
+
+# def test_deduplicate_is_duplicate():
+#     #  Setup tables for this event
+#     client = boto3.client("dynamodb")
+#     client.put_item(
+#         TableName=os.environ["SOCLESS_DEDUP_TABLE"],
+#         Item=dict_to_item(
+#             {
+#                 "dedup_hash": DEDUP_HASH_FOR_MOCK_EVENT,
+#                 "current_investigation_id": MOCK_INVESTIGATION_ID,
+#             },
+#             convert_root=False,
+#         ),
+#     )
+#     client.put_item(
+#         TableName=os.environ["SOCLESS_EVENTS_TABLE"],
+#         Item=dict_to_item(
+#             {
+#                 "id": MOCK_INVESTIGATION_ID,
+#                 "investigation_id": "already_running_id",
+#                 "status_": "open",
+#             },
+#             convert_root=False,
+#         ),
+#     )
+
+#     event = EventCreator(MOCK_EVENT)
+#     event.deduplicate()
+#     assert event.is_duplicate == True
+#     assert event.status_ == "closed"
+#     assert event.investigation_id == "already_running_id"
+
+
+# def test_deduplicate_is_duplicate_status_closed():
+#     #  Setup tables for this event
+#     client = boto3.client("dynamodb")
+#     client.put_item(
+#         TableName=os.environ["SOCLESS_DEDUP_TABLE"],
+#         Item=dict_to_item(
+#             {
+#                 "dedup_hash": DEDUP_HASH_FOR_MOCK_EVENT,
+#                 "current_investigation_id": MOCK_INVESTIGATION_ID,
+#             },
+#             convert_root=False,
+#         ),
+#     )
+#     client.put_item(
+#         TableName=os.environ["SOCLESS_EVENTS_TABLE"],
+#         Item=dict_to_item(
+#             {
+#                 "id": MOCK_INVESTIGATION_ID,
+#                 "investigation_id": "already_running_id",
+#                 "status_": "closed",
+#             },
+#             convert_root=False,
+#         ),
+#     )
+
+#     event = EventCreator(MOCK_EVENT)
+#     event.deduplicate()
+#     assert event.is_duplicate == False
+#     assert event.status_ == "open"
+
+
+# def test_deduplicate_is_duplicate_no_investigation_id():
+#     #  Setup dedup_hash for this event (without investigation id)
+#     client = boto3.client("dynamodb")
+#     client.put_item(
+#         TableName=os.environ["SOCLESS_DEDUP_TABLE"],
+#         Item=dict_to_item(
+#             {"dedup_hash": DEDUP_HASH_FOR_MOCK_EVENT}, convert_root=False
+#         ),
+#     )
+
+#     # investigation_id NOT saved in dedup table, not duplicate
+#     event = EventCreator(MOCK_EVENT)
+#     event.deduplicate()
+#     assert event.status_ == "open"
+#     assert event.is_duplicate == False
+
+
+# def test_deduplicate_is_unique():
+#     event = EventCreator(MOCK_EVENT)
+#     event.deduplicate()
+#     assert event.status_ == "open"
+#     assert event.is_duplicate == False
+
+
+# def test_EventCreator_create():
+#     event = EventCreator(MOCK_EVENT)
+
+#     created_event = event.create()
+
+#     # check dedup table
+#     dedup_table = boto3.resource("dynamodb").Table(os.environ["SOCLESS_DEDUP_TABLE"])
+#     dedup_mapping = dedup_table.get_item(Key={"dedup_hash": DEDUP_HASH_FOR_MOCK_EVENT})[
+#         "Item"
+#     ]
+
+#     assert (
+#         dedup_mapping["current_investigation_id"] == created_event["investigation_id"]
+#     )
+#     assert event.details == created_event["details"]
+#     assert event.created_at == created_event["created_at"]
+
+
+# def test_EventCreator_create_duplicate():
+#     #  Setup tables for this event
+#     client = boto3.client("dynamodb")
+#     client.put_item(
+#         TableName=os.environ["SOCLESS_DEDUP_TABLE"],
+#         Item=dict_to_item(
+#             {
+#                 "dedup_hash": DEDUP_HASH_FOR_MOCK_EVENT,
+#                 "current_investigation_id": MOCK_INVESTIGATION_ID,
+#             },
+#             convert_root=False,
+#         ),
+#     )
+#     client.put_item(
+#         TableName=os.environ["SOCLESS_EVENTS_TABLE"],
+#         Item=dict_to_item(
+#             {
+#                 "id": MOCK_INVESTIGATION_ID,
+#                 "investigation_id": "already_running_id",
+#                 "status_": "open",
+#             },
+#             convert_root=False,
+#         ),
+#     )
+
+#     edited_event = deepcopy(MOCK_EVENT)
+#     edited_event["dedup_keys"] = ["username"]
+
+#     event = EventCreator(edited_event)
+#     created_event = event.create()
+#     assert created_event["is_duplicate"] == True
+
+
+# def test_EventBatch():
+#     batched_event = EventBatch(MOCK_EVENT_BATCH, MockLambdaContext())
+
+#     assert batched_event.event_type == MOCK_EVENT_BATCH["event_type"]
+#     assert batched_event.created_at == None  # created_at not supplied in mock
+#     assert batched_event.details == MOCK_EVENT_BATCH["details"]
+#     assert batched_event.data_types == {}  # created_at not supplied in mock
+#     assert batched_event.dedup_keys == MOCK_EVENT_BATCH["dedup_keys"]
+#     assert batched_event.event_meta == {}
+#     assert batched_event.playbook == MOCK_EVENT_BATCH["playbook"]
+
+
+# def test_EventBatch_missing_details():
+#     bad_mock_event_batch = deepcopy(MOCK_EVENT_BATCH)
+#     del bad_mock_event_batch["details"]
+#     del bad_mock_event_batch["playbook"]
+
+#     batched_event = EventBatch(bad_mock_event_batch, MockLambdaContext())
+
+#     assert batched_event.playbook == ""
+#     assert batched_event.details == [{}]
+
+
+# def test_EventBatch_invalid_details_type():
+#     bad_mock_event_batch = deepcopy(MOCK_EVENT_BATCH)
+#     bad_mock_event_batch["details"] = "bad_arg"
+
+#     with pytest.raises(Exception):
+#         batched_event = EventBatch(bad_mock_event_batch, MockLambdaContext())
+
+
+# def test_EventBatch_invalid_playbook_type():
+#     bad_mock_event_batch = deepcopy(MOCK_EVENT_BATCH)
+#     bad_mock_event_batch["playbook"] = ["bad_arg"]
+
+#     with pytest.raises(Exception):
+#         batched_event = EventBatch(bad_mock_event_batch, MockLambdaContext())
+
+
+# def test_EventBatch_fails_on_invalid_type_for_dedup_keys():
+#     bad_mock_event_batch = deepcopy(MOCK_EVENT_BATCH)
+#     bad_mock_event_batch["dedup_keys"] = "bad_arg_type"
+
+#     with pytest.raises(Exception):
+#         batched_event = EventBatch(bad_mock_event_batch, MockLambdaContext())
+
+
+# @mock_stepfunctions
+# @mock_sts
+# @mock_iam
+# def test_EventBatch_execute_playbook():
+#     # setup playbook
+#     iam_client = boto3.client("iam", region_name="us-east-1")
+#     sts_client = boto3.client("sts", region_name="us-east-1")
+#     iam_role_name = "new-user"
+#     iam_role_arn = iam_client.role_arn = iam_client.create_role(
+#         RoleName=iam_role_name,
+#         AssumeRolePolicyDocument=json.dumps(iam_trust_policy_document),
+#     )["Role"]["Arn"]
+
+#     client = boto3.client("stepfunctions")
+#     sm = client.create_state_machine(
+#         name="ParamsToStateMachineTester",
+#         definition=str(playbook_definition),
+#         roleArn=iam_role_arn,
+#     )
+
+#     batched_event = EventBatch(MOCK_EVENT_BATCH, MockLambdaContext())
+#     result = batched_event.execute_playbook(convert_empty_strings_to_none(MOCK_EVENT))
+
+#     assert result["status"] == True
+#     assert isinstance(result["message"]["execution_id"], str)
+#     assert isinstance(result["message"]["investigation_id"], str)
+
+
+# def test_EventBatch_execute_playbook_failure():
+#     edited_event = deepcopy(MOCK_EVENT_BATCH)
+#     edited_event["playbook"] = "bad_playbook"
+
+#     batched_event = EventBatch(edited_event, MockLambdaContext())
+#     result = batched_event.execute_playbook(convert_empty_strings_to_none(MOCK_EVENT))
+
+#     assert result["status"] == False
+
+
+# @mock_stepfunctions
+# @mock_sts
+# @mock_iam
+# def test_EventBatch_create_events():
+#     # setup playbook
+#     iam_client = boto3.client("iam", region_name="us-east-1")
+#     sts_client = boto3.client("sts", region_name="us-east-1")
+#     iam_role_name = "new-user"
+#     iam_role_arn = iam_client.role_arn = iam_client.create_role(
+#         RoleName=iam_role_name,
+#         AssumeRolePolicyDocument=json.dumps(iam_trust_policy_document),
+#     )["Role"]["Arn"]
+
+#     client = boto3.client("stepfunctions")
+#     sm = client.create_state_machine(
+#         name="ParamsToStateMachineTester",
+#         definition=str(playbook_definition),
+#         roleArn=iam_role_arn,
+#     )
+
+#     batched_event = EventBatch(MOCK_EVENT_BATCH, MockLambdaContext())
+
+#     result = batched_event.create_events()
+
+#     #! FIX: result['status'] is always true, message is a list of individual
+#     #! playbook responses that may be true or false (error) responses
+#     assert result["status"] == True
+
+#     assert result["message"][0]["status"] == True
+#     assert result["message"][1]["status"] == True
+
+
+# def test_create_events():
+#     from socless.events import create_events
+
+#     create_events_result = create_events(MOCK_EVENT_BATCH, MockLambdaContext())
+
+#     assert create_events_result["status"] == True


### PR DESCRIPTION
Does not attempt to change any of the logic for turning an event into a playbook execution. Focuses on removing the EventBatch, EventCreator classes into Event classes with methods that use the event.

Simliarly, `create_events()` spells out more of whats going on by directly calling the necessary methods from event formatting all the way to playbook start. 

Breaking these methods up away from init() functions or nested in other methods will help as we decide whether all these steps will ultimately be necessary in `2.0.0`

- The only major feature improvement besides cleanup is that create_events() can now support a single event with `event["details"]` as a dict in addition to the previously supported format of multiple events with details as a list of dicts.

--------
Previous create_events() call flow:
1. `create_events` calls `EventBatch().create_events`
2. `EventBatch()` init ensures the event keys are the right types
3. `EventBatch().create_events` says for each event in details list:
   1.  format the event to a new structure and then call `EventCreator(new_event).create()`
   2.  `EventBatch().execute_playbook()` - step 7
4.  `EventCreator` init validates event key types
5.  `EventCreator` `.create()` calls `.deduplicate()` which interacts with DEDUP_TABLE and mutates the event
6.  `.create()` then formats the event and puts it into the EVENTS_TABLE
7.  `EventBatch().execute_playbook()` 
    1.  formats the playbook metadata (arn, investigation_id, input dict)
    2.  puts an item in the results table
    3.  starts stepFunctions with a subset of results item

After this PR:
1. create_events:
   1. generates a datetime for all events
   2. converts all events into an InitialEvent dataclass which checks types
   3. for each event in the list:
      1. feed the initialevent class into a completeevent class which generates metadata and methods surrounding the initialevent struct
      2. deduplicate
      3. put_item of event in events_table
      4. start_playbook
      5. save a message about whether that playbook started
   4. raise an error after all messages are started, if any of them failed to start

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
