### PR TITLE
Ensure Floats and Decimals are handled correctly when going in/coming out of Dynamodb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ venv*
 .coverage
 htmlcov
 .vscode/*
+# pyenv local config
+.python-version

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License
-from setuptools import setup, find_packages
+from setuptools import setup
 
 
 setup(
@@ -26,6 +26,6 @@ setup(
     ],
     keywords="socless security orchestration automation",
     packages=["socless"],
-    install_requires=["simplejson", "jinja2"],
+    install_requires=["simplejson", "jinja2", "pytz"],
     tests_require=["tox"],
 )

--- a/socless/integrations.py
+++ b/socless/integrations.py
@@ -17,7 +17,11 @@ Classes and modules for Integrations
 import boto3, os
 from typing import Callable
 from .logger import socless_log
-from .utils import convert_empty_strings_to_none
+from .utils import (
+    convert_empty_strings_to_none,
+    replace_decimals,
+    replace_floats_with_decimals,
+)
 from .exceptions import SoclessException, SoclessBootstrapError
 from .aws_classes import LambdaContext
 from .legacy_jinja import legacy_jinja_env
@@ -51,7 +55,7 @@ class ExecutionContext:
                 f"Error: Unable to get execution_id {self.execution_id} from {RESULTS_TABLE}."
             )
 
-        return item
+        return replace_decimals(item)
 
     def save_state_results(self, state_name, result, errors={}):
         """Save the results of a State's execution to the Execution results table
@@ -61,6 +65,7 @@ class ExecutionContext:
         """
         RESULTS_TABLE = os.environ.get("SOCLESS_RESULTS_TABLE")
         results_table = boto3.resource("dynamodb").Table(RESULTS_TABLE)
+        result = replace_floats_with_decimals(result)
 
         error_expression = ""
         expression_attributes = {":r": result}

--- a/socless/jinja.py
+++ b/socless/jinja.py
@@ -88,8 +88,10 @@ def env(env_var_name: str) -> str:
 
     try:
         return os.environ[env_var_name]
-    except KeyError:
-        raise SoclessBootstrapError(f"Environment Variable {env_var_name} not found")
+    except KeyError as e:
+        raise SoclessBootstrapError(
+            f"Environment Variable {env_var_name} not found"
+        ) from e
 
 
 def fromtimestamp(timestamp: Union[int, str], tz: str = "UTC") -> str:
@@ -105,11 +107,13 @@ def fromtimestamp(timestamp: Union[int, str], tz: str = "UTC") -> str:
     except ValueError as e:
         raise SoclessBootstrapError(
             f"Failed to convert {timestamp} to integer. {timestamp} is not a valid timestamp. Error: {e}"
-        )
+        ) from e
     try:
         tzinfo = timezone(tz)
     except UnknownTimeZoneError as e:
-        raise SoclessBootstrapError(f"{tz} is not a valid timezone name. Error: {e}")
+        raise SoclessBootstrapError(
+            f"{tz} is not a valid timezone name. Error: {e}"
+        ) from e
     return datetime.fromtimestamp(int(timestamp), tz=tzinfo).isoformat()
 
 

--- a/socless/utils.py
+++ b/socless/utils.py
@@ -16,8 +16,15 @@ utils.py - Contains utility functions
 """
 import uuid
 from datetime import datetime
+from decimal import Decimal
 
-__all__ = ["gen_id", "gen_datetimenow", "convert_empty_strings_to_none"]
+__all__ = [
+    "gen_id",
+    "gen_datetimenow",
+    "convert_empty_strings_to_none",
+    "replace_decimals",
+    "replace_floats_with_decimals",
+]
 
 
 def gen_id(limit=36):
@@ -64,3 +71,31 @@ def convert_empty_strings_to_none(nested_dict):
             else:
                 converted_dict[k] = v
     return converted_dict
+
+
+def replace_decimals(obj: object) -> object:
+    """
+    Replaces instances of `Decimal` type with either `int` or `float`
+    """
+    if isinstance(obj, list):
+        return [replace_decimals(i) for i in obj]
+    elif isinstance(obj, dict):
+        return {k: replace_decimals(v) for k, v in obj.items()}
+    elif isinstance(obj, Decimal):
+        return float(obj) if "." in str(obj) else int(obj)
+    else:
+        return obj
+
+
+def replace_floats_with_decimals(obj: object) -> object:
+    """
+    Replaces floats with Decimals
+    """
+    if isinstance(obj, list):
+        return [replace_floats_with_decimals(i) for i in obj]
+    elif isinstance(obj, dict):
+        return {k: replace_floats_with_decimals(v) for k, v in obj.items()}
+    elif isinstance(obj, float):
+        return Decimal(str(obj))
+    else:
+        return obj

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -60,8 +60,10 @@ def dict_to_item(raw, convert_root=True):
         # item =  {'S': raw if raw else None} #replace empty strings with None
     elif isinstance(raw, bool):
         item = {"BOOL": raw}
-    elif isinstance(raw, int):
+    elif isinstance(raw, (int, float)):
         item = {"N": str(raw)}
+    else:
+        item = {"M": {}}
 
     return item if convert_root else item["M"]
 
@@ -83,7 +85,11 @@ def mock_execution_results_table_entry():
                     "id": random_id,
                     "created_at": date_time,
                     "data_types": {},
-                    "details": {"some": "randon text"},
+                    "details": {
+                        "some": "randon text",
+                        "some_int": 47,
+                        "some_float": 0.07,
+                    },
                     "event_type": "Test integrations",
                     "event_meta": {},
                     "investigation_id": investigation_id,

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -46,7 +46,11 @@ def test_ExecutionContext_fetch_context():
                     "id": item_metadata["id"],
                     "created_at": item_metadata["datetime"],
                     "data_types": {},
-                    "details": {"some": "randon text"},
+                    "details": {
+                        "some": "randon text",
+                        "some_int": 47,
+                        "some_float": 0.07,
+                    },
                     "event_type": "Test integrations",
                     "event_meta": {},
                     "investigation_id": item_metadata["investigation_id"],
@@ -74,7 +78,7 @@ def test_ExecutionContext_save_state_results():
     # test ExecutionContext save state results to assert saved item is as expected
     item_metadata = mock_execution_results_table_entry()
     state_name = "test_ExecutionContext_save_state_results"
-    result = {"exist": True}
+    result = {"exist": True, "float": 1.0}
     errors = {"error": "This is an error"}
     execution = ExecutionContext(item_metadata["execution_id"])
     execution.save_state_results(state_name=state_name, result=result, errors=errors)
@@ -87,6 +91,7 @@ def test_ExecutionContext_save_state_results():
     assert saved_result["Item"]["execution_id"] == item_metadata["execution_id"]
     assert saved_result["Item"]["investigation_id"] == item_metadata["investigation_id"]
     assert saved_result["Item"]["datetime"] == item_metadata["datetime"]
+    assert saved_result["Item"]["results"]["results"][state_name] == result
 
 
 def test_StateHandler_init_with_testing_event():
@@ -142,7 +147,11 @@ def test_StateHandler_init_with_live_event():
                     "id": item_metadata["id"],
                     "created_at": item_metadata["datetime"],
                     "data_types": {},
-                    "details": {"some": "randon text"},
+                    "details": {
+                        "some": "randon text",
+                        "some_int": 47,
+                        "some_float": 0.07,
+                    },
                     "event_type": "Test integrations",
                     "event_meta": {},
                     "investigation_id": item_metadata["investigation_id"],
@@ -224,7 +233,11 @@ def test_StateHandler_init_with_live_event_with_errors():
                     "id": item_metadata["id"],
                     "created_at": item_metadata["datetime"],
                     "data_types": {},
-                    "details": {"some": "randon text"},
+                    "details": {
+                        "some": "randon text",
+                        "some_int": 47,
+                        "some_float": 0.07,
+                    },
                     "event_type": "Test integrations",
                     "event_meta": {},
                     "investigation_id": item_metadata["investigation_id"],
@@ -392,7 +405,11 @@ def test_StateHandler_execute_with_live_event_include_context():
                 "id": item_metadata["id"],
                 "created_at": item_metadata["datetime"],
                 "data_types": {},
-                "details": {"some": "randon text"},
+                "details": {
+                    "some": "randon text",
+                    "some_int": 47,
+                    "some_float": 0.07,
+                },
                 "event_type": "Test integrations",
                 "event_meta": {},
                 "investigation_id": item_metadata["investigation_id"],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,9 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License
-from socless.utils import gen_id, gen_datetimenow, convert_empty_strings_to_none
-import unittest
+from os import replace
+from socless.utils import (
+    gen_id,
+    gen_datetimenow,
+    convert_empty_strings_to_none,
+    replace_decimals,
+    replace_floats_with_decimals,
+)
 from copy import deepcopy
+from decimal import Decimal
 
 
 def test_gen_datetimenow():
@@ -47,3 +54,51 @@ def test_convert_empty_strings_to_none():
     expected_output["errors"]["TEST_nested_list_empty_dict"][0]["var1"] = None
 
     assert convert_empty_strings_to_none(testDict) == expected_output
+
+
+def test_replace_decimals():
+
+    int_one = replace_decimals(Decimal("1"))
+    float_one = replace_decimals(Decimal("1.0"))
+
+    # Because 1.0 == 1 in Python, we also have to assert the correct type is returned
+    assert int_one == 1 and isinstance(int_one, int)
+    assert float_one == 1.0 and isinstance(float_one, float)
+
+    assert replace_decimals([1, Decimal("1")]) == [1, 1]
+    assert replace_decimals(
+        {
+            "int": 1,
+            "float": 1.0,
+            "bool": True,
+            "string": "hello",
+            "list": [1, Decimal("1")],
+            "decimal": Decimal("1.0"),
+            "nested_dict": {"decimal": Decimal("1")},
+        }
+    ) == {
+        "int": 1,
+        "float": 1.0,
+        "bool": True,
+        "string": "hello",
+        "list": [1, 1],
+        "decimal": 1.0,
+        "nested_dict": {"decimal": 1},
+    }
+
+
+def test_replace_floats_with_decimals():
+    assert replace_floats_with_decimals(1.0) == Decimal("1.0")
+    assert replace_floats_with_decimals(
+        {
+            "int": 1,
+            "float": 1.0,
+            "list": [1, 1.0],
+            "dict": {"int": 1, "float": 1.0},
+        }
+    ) == {
+        "int": 1,
+        "float": Decimal("1.0"),
+        "list": [1, Decimal("1.0")],
+        "dict": {"int": 1, "float": Decimal("1.0")},
+    }


### PR DESCRIPTION
Background:
DynamoDb has only one number type, `Number`, but Python has `int`, `float` & `Decimal` types. When boto3 loads `Numbers` from DynamoDB, it returns them as `Decimal` objects instead of int or float. In addition, boto3 does not accept `float` in objects destined for DynamoDB. It expects them to be converted to Decimal types first before saving. These two behaviors often cause bugs for SOCless integrations that work with numbers.

This PR aims to prevent those bugs in integrations by automatically handling the conversion between Decimals, floats and ints when data is being loaded from and saved to DynamoDB.


In addition. this PR includes small fixes and changes for some bugs:
* it fixes a bug resulting from the pytz dependency used`fromtimestamp` function being missing from the package. Our tests did not initially catch this missing dependency because the `moto` library includes pytz, allowing tests to pass, but causing the production package to fail



<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
